### PR TITLE
Add H3 toolkit and deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ The project combines a searchable visual website, Prompt-as-Code templates, a ma
 | [`agents/skills/minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) | Agent Skill for retrieving and adapting prompt patterns |
 | [`docs/DISCOVERY_WORKFLOW.md`](./docs/DISCOVERY_WORKFLOW.md) | Browser-based X discovery, deduplication, review, and attribution rules |
 
+## H3 toolkit and deployment guides
+
+| Resource | Start here for | Link |
+| --- | --- | --- |
+| Official MiniMax H3 repository | Weights, deployment guidance, and nine bundled Agent Skills including `h3-prompt-writing` | [MiniMax-AI/MiniMax-H3](https://github.com/MiniMax-AI/MiniMax-H3) |
+| MiniMax-H3 Turbo LoRA | Few-step synchronized audio-video generation; use 4 steps for previews and typically 6–8 for stronger v4 output | [larryvrh/MiniMax-H3-Turbo-Lora](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) |
+| ComfyUI H3 Motion Context | Chaining clips while carrying motion and audio context across joins | [NikoDemon80/ComfyUI-H3-Motion-Context](https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context) |
+| MiniMax H3 Audio T8 | Native H3 audio conditioning, dual-clock sampling, mixing, trimming, preflight, and Ref2VA workflows | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
+
+A practical acceleration starting point is **Turbo LoRA + SageAttention**. EasyCache targets the native 20-step path and is not recommended on top of a 4-step Turbo graph. Fewer sampling steps also do not translate into the same end-to-end speedup because VAE decoding and video packaging remain. The roadmap connects `Agent + h3-prompt-writing → ComfyUI API → Remotion` for automated prompting, generation, and editing.
+
 ## Generation modes
 
 - **T2VA — text-to-video with audio:** cinematic shots, camera movement, dialogue, music, ambience, and timeline cues from text.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,17 @@ Awesome MiniMax H3 是一个带来源追踪的开源 AI 视频提示词案例库
 | [`CATALOG.md`](./CATALOG.md) | GitHub 原生案例索引 |
 | [`agents/skills/minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) | 用于检索和改写提示词的 Agent Skill |
 
+## H3 工具链与部署入口
+
+| 资源 | 先看什么 | 地址 |
+| --- | --- | --- |
+| MiniMax H3 官方仓库 | 权重、部署说明，以及包括 `h3-prompt-writing` 在内的 9 个 Agent Skill | [MiniMax-AI/MiniMax-H3](https://github.com/MiniMax-AI/MiniMax-H3) |
+| MiniMax-H3 Turbo LoRA | 4–8 步同步音视频加速；4 步预览，v4 在 6–8 步通常更稳 | [larryvrh/MiniMax-H3-Turbo-Lora](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) |
+| ComfyUI H3 Motion Context | 多片段续接，延续上一段的画面运动与音频上下文 | [NikoDemon80/ComfyUI-H3-Motion-Context](https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context) |
+| MiniMax H3 Audio T8 | 原生 H3 音频条件、双时钟采样、混音、裁切、预检与 Ref2VA 工作流 | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
+
+实践路线优先尝试 **Turbo LoRA + SageAttention**。EasyCache 更适合原生 20 步链路，不建议和 4 步 Turbo 叠加；采样步数的缩短也不等于端到端等比例加速，VAE 解码和视频封装仍会占用时间。下一阶段路线图是：`Agent + h3-prompt-writing → ComfyUI API → Remotion`，完成从提示词、生成到剪辑交付的自动化链路。
+
 ## 自动采集路线
 
 ```text

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0b09" />
-    <meta name="description" content="MiniMax H3 / Hailuo 3.0 AI 视频案例、提示词模板与可复现工作流。覆盖文字生视频、首尾帧、全模态参考、运镜、原生音频和角色一致性。" />
-    <meta name="keywords" content="MiniMax H3,Hailuo 3.0,海螺 AI,AI video generation,video prompts,视频提示词,text to video,image to video,video to video,prompt engineering,T2VA,FL2VA,Ref2VA" />
+    <meta name="description" content="MiniMax H3 / Hailuo 3.0 AI 视频案例、提示词模板、部署教程与 ComfyUI 工具链。收录 H3 Skills、Turbo LoRA、长视频续接和音视频工作流。" />
+    <meta name="keywords" content="MiniMax H3,Hailuo 3.0,海螺 AI,MiniMax H3 部署,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio,AI video generation,video prompts,视频提示词,T2VA,FL2VA,Ref2VA" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-video-preview:-1" />
     <link rel="canonical" href="https://h3-field-notes-production.up.railway.app/" />
     <link rel="alternate" hreflang="zh-CN" href="https://h3-field-notes-production.up.railway.app/" />
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="H3 Field Notes" />
     <meta property="og:title" content="Awesome MiniMax H3 — Hailuo 3.0 视频提示词案例库" />
-    <meta property="og:description" content="可筛选、可追溯、可复现的 MiniMax H3 AI 视频案例与 Prompt-as-Code 模板。" />
+    <meta property="og:description" content="可筛选、可追溯的 MiniMax H3 视频案例，以及 Skills、Turbo LoRA、ComfyUI 部署和音视频工作流。" />
     <meta property="og:url" content="https://h3-field-notes-production.up.railway.app/" />
     <meta property="og:image" content="https://h3-field-notes-production.up.railway.app/og-image.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -28,14 +28,36 @@
         "name": "Awesome MiniMax H3 / Hailuo 3.0 Video Prompt Library",
         "alternateName": "H3 Field Notes",
         "url": "https://h3-field-notes-production.up.railway.app/",
-        "description": "A source-attributed library of MiniMax H3 AI video examples, prompts, templates, and reproducible workflows.",
+        "description": "A source-attributed library of MiniMax H3 AI video examples, prompts, deployment guides, ComfyUI tools, and reproducible workflows.",
         "inLanguage": ["zh-CN", "en"],
         "isPartOf": {
           "@type": "WebSite",
           "name": "H3 Field Notes",
           "url": "https://h3-field-notes-production.up.railway.app/"
         },
-        "about": ["MiniMax H3", "Hailuo 3.0", "AI video generation", "video prompt engineering"]
+        "about": ["MiniMax H3", "Hailuo 3.0", "AI video generation", "video prompt engineering", "ComfyUI", "Turbo LoRA"],
+        "hasPart": [
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "MiniMax H3 official repository and Agent Skills",
+            "codeRepository": "https://github.com/MiniMax-AI/MiniMax-H3"
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "MiniMax-H3 Turbo LoRA",
+            "url": "https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora"
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "ComfyUI H3 Motion Context",
+            "codeRepository": "https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context"
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "MiniMax H3 Audio T8",
+            "codeRepository": "https://github.com/T8mars/comfyui-minimax-h3-audio-T8"
+          }
+        ]
       }
     </script>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230a0b09'/%3E%3Cpath d='M14 16h8v12h20V16h8v32h-8V36H22v12h-8z' fill='%23d8ff3e'/%3E%3C/svg%3E" />

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -37,6 +37,14 @@ Primary language: Chinese; English metadata and documentation are available.
 - https://github.com/SkyNotSilent/awesome-minimax-h3/blob/main/data/cases.json: machine-readable public cases with source and verification status
 - https://github.com/SkyNotSilent/awesome-minimax-h3/blob/main/data/templates.json: reusable Prompt-as-Code templates
 
+## H3 toolkit and deployment resources
+
+- https://github.com/MiniMax-AI/MiniMax-H3: official weights, deployment documentation, and nine bundled Agent Skills including h3-prompt-writing
+- https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora: 4–8 step synchronized audio-video acceleration LoRA for ComfyUI
+- https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context: long-video clip chaining with motion and audio continuity
+- https://github.com/T8mars/comfyui-minimax-h3-audio-T8: native H3 audio conditioning, sampling, mixing, trimming, and Ref2VA nodes
+- Roadmap: h3-prompt-writing Agent → ComfyUI API generation → Remotion automated editing
+
 ## Terminology
 
 - MiniMax H3 and Hailuo 3.0 refer to the model family documented by this community project.

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "H3 Field Notes — Awesome MiniMax H3",
   "short_name": "H3 Field Notes",
-  "description": "MiniMax H3 / Hailuo 3.0 AI video prompts, examples, and workflows.",
+  "description": "MiniMax H3 / Hailuo 3.0 AI video prompts, examples, deployment guides, ComfyUI workflows, and tools.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0b09",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -59,4 +59,26 @@ describe('case catalog', () => {
     expect(screen.getByText('九图参考 AI 电影预告')).toBeInTheDocument()
     expect(screen.queryByText('舰桥上的跃迁余震')).not.toBeInTheDocument()
   })
+
+  it('publishes the four-part H3 toolkit instead of a standalone weights link', () => {
+    render(<App />)
+    expect(screen.getByRole('link', { name: '工具链' })).toHaveAttribute('href', '#toolkit')
+    expect(screen.getByRole('link', { name: 'MiniMax-AI / MiniMax-H3：打开官方仓库' })).toHaveAttribute(
+      'href',
+      'https://github.com/MiniMax-AI/MiniMax-H3',
+    )
+    expect(screen.getByRole('link', { name: 'MiniMax-H3 Turbo LoRA：打开 Hugging Face' })).toHaveAttribute(
+      'href',
+      'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
+    )
+    expect(screen.getByRole('link', { name: 'ComfyUI H3 Motion Context：打开续接节点' })).toHaveAttribute(
+      'href',
+      'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
+    )
+    expect(screen.getByRole('link', { name: 'MiniMax H3 Audio T8：打开音频工作流' })).toHaveAttribute(
+      'href',
+      'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
+    )
+    expect(screen.queryByRole('link', { name: /模型权重/ })).not.toBeInTheDocument()
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,45 @@ const modeCopy: Record<(typeof modes)[number], string> = {
   Unknown: '模式待确认',
 }
 
+const toolkitResources = [
+  {
+    code: 'R01',
+    kind: 'OFFICIAL / SKILLS',
+    title: 'MiniMax-AI / MiniMax-H3',
+    description: '官方仓库与本地部署入口。内置 9 个 Agent Skill；先装 h3-prompt-writing，让 Claude / Codex 按镜头、对白与环境声组织 H3 提示词。',
+    tags: ['9 Skills', 'Prompt Writing', 'Local Deploy'],
+    url: 'https://github.com/MiniMax-AI/MiniMax-H3',
+    action: '打开官方仓库',
+  },
+  {
+    code: 'R02',
+    kind: 'ACCELERATION / LORA',
+    title: 'MiniMax-H3 Turbo LoRA',
+    description: '将常规约 20 步采样压缩到 4–8 步并保留同步立体声音频。4 步用于快速预览，v4 版本在 6–8 步通常更稳。',
+    tags: ['4–8 Steps', 'Audio + Video', 'ComfyUI'],
+    url: 'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
+    action: '打开 Hugging Face',
+  },
+  {
+    code: 'R03',
+    kind: 'LONG VIDEO / CONTEXT',
+    title: 'ComfyUI H3 Motion Context',
+    description: '用于多段 H3 视频续接，把上一段的画面与音频上下文带入下一段，减少片段连接处的动作、节奏和声音断裂。',
+    tags: ['Clip Chaining', 'Motion Context', 'Audio Continuity'],
+    url: 'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
+    action: '打开续接节点',
+  },
+  {
+    code: 'R04',
+    kind: 'AUDIO / WORKFLOWS',
+    title: 'MiniMax H3 Audio T8',
+    description: '面向 ComfyUI 原生 H3 的 14 节点扩展，覆盖音频条件、双时钟采样、混音、裁切、预检和 Ref2VA 参考，并附 API 与前端工作流。',
+    tags: ['14 Nodes', 'Dual Clock', 'Audio Control'],
+    url: 'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
+    action: '打开音频工作流',
+  },
+]
+
 function App() {
   const [activeMode, setActiveMode] = useState<(typeof modes)[number]>('ALL')
   const [activeCategory, setActiveCategory] = useState('ALL')
@@ -163,6 +202,7 @@ function App() {
       </section>
 
       <Templates />
+      <Toolkit />
       <Method />
       <FAQ />
       <Footer />
@@ -180,11 +220,9 @@ function Header() {
       <nav>
         <a href="#catalog">案例</a>
         <a href="#templates">模板</a>
+        <a href="#toolkit">工具链</a>
         <a href="#method">收录方式</a>
         <a href="#faq">常见问题</a>
-        <a href="https://huggingface.co/MiniMaxAI/MiniMax-H3" target="_blank" rel="noreferrer">
-          模型权重 <ArrowUpRight size={13} />
-        </a>
       </nav>
       <a
         className="source-button"
@@ -328,11 +366,75 @@ function Templates() {
   )
 }
 
+function Toolkit() {
+  return (
+    <section className="toolkit shell" id="toolkit">
+      <div className="toolkit-heading">
+        <div>
+          <p className="section-index">03 / H3 FIELD KIT</p>
+          <h2>从提示词，<br />一路接到成片。</h2>
+        </div>
+        <p>
+          不只给模型权重。这里整理真正会影响落地效率的官方 Skill、加速 LoRA、长视频续接与音视频工作流。
+        </p>
+      </div>
+
+      <div className="toolkit-grid">
+        {toolkitResources.map((item) => (
+          <a
+            className="resource-card"
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+            key={item.code}
+            aria-label={`${item.title}：${item.action}`}
+          >
+            <div className="resource-topline">
+              <span>{item.code}</span>
+              <span>{item.kind}</span>
+            </div>
+            <h3>{item.title}</h3>
+            <p>{item.description}</p>
+            <div className="resource-tags">
+              {item.tags.map((tag) => <span key={tag}>{tag}</span>)}
+            </div>
+            <div className="resource-action">
+              {item.action} <ArrowUpRight size={15} />
+            </div>
+          </a>
+        ))}
+      </div>
+
+      <div className="toolkit-notes">
+        <article className="speed-note">
+          <div className="note-label">FIELD NOTE / 速度组合</div>
+          <h3>少叠插件，先把采样链路跑稳。</h3>
+          <p>
+            实战优先尝试 <strong>Turbo LoRA + SageAttention</strong>。4 步适合预览，6–8 步用于成片；EasyCache 更适合原生 20 步工作流，不建议和 4 步 Turbo 叠加。端到端速度仍会受到 VAE 解码与视频封装影响。
+          </p>
+          <small>生态观察：当前 H3 LoRA 热点集中在加速，人物与画风训练仍处于早期。</small>
+        </article>
+
+        <article className="pipeline-note">
+          <div className="note-label">NEXT PIPELINE / 无人出片</div>
+          <div className="pipeline-flow" aria-label="下一步自动化路线">
+            <div><span>01</span><strong>AGENT</strong><small>h3-prompt-writing</small></div>
+            <ChevronRight size={18} aria-hidden="true" />
+            <div><span>02</span><strong>COMFYUI API</strong><small>生成音视频</small></div>
+            <ChevronRight size={18} aria-hidden="true" />
+            <div><span>03</span><strong>REMOTION</strong><small>自动剪辑与交付</small></div>
+          </div>
+        </article>
+      </div>
+    </section>
+  )
+}
+
 function Method() {
   return (
     <section className="method shell" id="method">
       <div className="method-heading">
-        <p className="section-index">03 / 收录方式</p>
+        <p className="section-index">04 / 收录方式</p>
         <h2>不是热度榜。<br />是可验证的实验记录。</h2>
       </div>
       <div className="method-steps">
@@ -360,7 +462,7 @@ function FAQ() {
   return (
     <section className="faq shell" id="faq">
       <div className="faq-heading">
-        <p className="section-index">04 / FAQ</p>
+        <p className="section-index">05 / FAQ</p>
         <h2>关于 MiniMax H3<br />视频提示词案例库</h2>
       </div>
       <div className="faq-list">

--- a/src/styles.css
+++ b/src/styles.css
@@ -705,6 +705,238 @@ a {
   border-color: var(--acid);
 }
 
+.toolkit {
+  padding: 120px 0;
+  border-top: 1px solid var(--line);
+}
+
+.toolkit-heading {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  align-items: end;
+  gap: 10vw;
+}
+
+.toolkit-heading h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(42px, 6vw, 78px);
+  line-height: 1.02;
+  letter-spacing: -0.06em;
+  text-transform: uppercase;
+}
+
+.toolkit-heading > p {
+  max-width: 620px;
+  margin: 0 0 7px;
+  color: #a4a89e;
+  font-size: 16px;
+  font-weight: 300;
+  line-height: 1.9;
+}
+
+.toolkit-grid {
+  margin-top: 68px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border-top: 1px solid #4a4e45;
+  border-left: 1px solid #4a4e45;
+}
+
+.resource-card {
+  position: relative;
+  min-height: 340px;
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: rgba(17, 19, 15, 0.48);
+  border-right: 1px solid #4a4e45;
+  border-bottom: 1px solid #4a4e45;
+  transition: color 200ms ease, background 200ms ease, transform 200ms ease;
+}
+
+.resource-card::after {
+  content: '';
+  position: absolute;
+  right: -70px;
+  bottom: -70px;
+  width: 150px;
+  height: 150px;
+  border: 1px solid rgba(217, 255, 67, 0.25);
+  border-radius: 50%;
+  transition: transform 320ms ease, background 320ms ease;
+}
+
+.resource-card:hover {
+  color: var(--ink);
+  background: #171a14;
+  transform: translateY(-4px);
+}
+
+.resource-card:hover::after {
+  background: rgba(217, 255, 67, 0.08);
+  transform: scale(1.35);
+}
+
+.resource-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.resource-topline span:first-child {
+  color: var(--acid);
+}
+
+.resource-card h3 {
+  max-width: 520px;
+  margin: 52px 0 16px;
+  font-family: var(--display);
+  font-size: clamp(28px, 3vw, 42px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.resource-card > p {
+  max-width: 590px;
+  margin: 0;
+  color: #979b91;
+  font-size: 13px;
+  font-weight: 300;
+  line-height: 1.8;
+}
+
+.resource-tags {
+  margin-top: 25px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.resource-tags span {
+  padding: 4px 6px;
+  color: #7f8379;
+  border: 1px solid #353930;
+  font-family: var(--mono);
+  font-size: 8px;
+  text-transform: uppercase;
+}
+
+.resource-action {
+  z-index: 1;
+  margin-top: auto;
+  padding-top: 30px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.toolkit-notes {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 24px;
+}
+
+.speed-note,
+.pipeline-note {
+  min-height: 260px;
+  padding: 30px;
+  border: 1px solid #3d4138;
+}
+
+.speed-note {
+  color: #0a0b09;
+  background: var(--acid);
+  border-color: var(--acid);
+}
+
+.note-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.speed-note h3 {
+  margin: 42px 0 14px;
+  font-family: var(--display);
+  font-size: 32px;
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+}
+
+.speed-note p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.speed-note small {
+  display: block;
+  margin-top: 22px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(10, 11, 9, 0.28);
+  font-family: var(--mono);
+  font-size: 9px;
+}
+
+.pipeline-note {
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(rgba(217, 255, 67, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(217, 255, 67, 0.035) 1px, transparent 1px),
+    #0d0f0c;
+  background-size: 24px 24px;
+}
+
+.pipeline-note .note-label {
+  color: var(--acid);
+}
+
+.pipeline-flow {
+  margin: auto 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+}
+
+.pipeline-flow > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pipeline-flow span,
+.pipeline-flow small {
+  font-family: var(--mono);
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.pipeline-flow strong {
+  margin: 10px 0 5px;
+  font-family: var(--display);
+  font-size: 21px;
+  line-height: 1;
+}
+
+.pipeline-flow > svg {
+  color: var(--acid);
+}
+
 .method {
   padding: 120px 0;
   display: grid;
@@ -1080,6 +1312,8 @@ footer > span {
   .method { grid-template-columns: 1fr; gap: 60px; }
   .faq { grid-template-columns: 1fr; gap: 60px; }
   .templates { grid-template-columns: 1fr; gap: 60px; }
+  .toolkit-heading { grid-template-columns: 1fr; gap: 36px; }
+  .toolkit-notes { grid-template-columns: 1fr; }
   .method-heading { position: static; }
   .case-dialog { grid-template-columns: 1fr; }
   .dialog-video { position: static; min-height: 0; }
@@ -1107,6 +1341,13 @@ footer > span {
   .method { padding: 84px 0; }
   .faq { padding: 84px 0; }
   .templates { padding: 84px 0; }
+  .toolkit { padding: 84px 0; }
+  .toolkit-grid { grid-template-columns: 1fr; margin-top: 48px; }
+  .resource-card { min-height: 310px; padding: 24px; }
+  .resource-card h3 { margin-top: 38px; }
+  .speed-note, .pipeline-note { min-height: 0; padding: 24px; }
+  .pipeline-flow { margin-top: 54px; grid-template-columns: 1fr; gap: 14px; }
+  .pipeline-flow > svg { transform: rotate(90deg); }
   .template-list article { grid-template-columns: 52px 1fr; }
   .template-list article > button { grid-column: 2; justify-self: start; }
   footer { padding: 38px 0; grid-template-columns: 1fr; text-align: left; }


### PR DESCRIPTION
## What changed

- replaced the standalone model-weights navigation link with an in-page H3 toolkit
- added official Skills, Turbo LoRA, Motion Context, and Audio T8 resource cards
- documented the practical acceleration note and Agent → ComfyUI API → Remotion roadmap
- expanded README, llms.txt, manifest, metadata, keywords, and JSON-LD for deployment and ComfyUI discovery

## Why

Visitors need actionable deployment and workflow entry points, not only a model-weight link. The new section turns four verified primary resources into a scannable field guide while keeping performance observations clearly separated from repository-backed facts.

## Verification

- `npm test -- --run` — 6 tests passed
- `npm run lint`
- `npm run validate:data` — 25 cases and 3 templates
- `npm run build` — production build completed
- `npm run catalog`
- desktop and 390px mobile browser checks; no horizontal overflow
- all four external resources returned HTTP 200 or were verified through their primary repository API
