### PR TITLE
feat: bilingual case-first H3 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # Awesome MiniMax H3
 
-### Curated MiniMax H3 / Hailuo 3.0 AI video prompts, examples, templates, and reproducible workflows
+### Curated MiniMax H3 / Hailuo 3.0 AI video examples, prompt records, and reproducible workflows
 
 [![Website](https://img.shields.io/badge/Live-H3_Field_Notes-d8ff3e?style=flat-square&labelColor=0a0b09)](https://h3-field-notes-production.up.railway.app/)
 [![Cases](https://img.shields.io/badge/public_cases-25-d8ff3e?style=flat-square&labelColor=0a0b09)](./CATALOG.md)
 [![CI](https://github.com/SkyNotSilent/awesome-minimax-h3/actions/workflows/ci.yml/badge.svg)](https://github.com/SkyNotSilent/awesome-minimax-h3/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/code-MIT-blue.svg?style=flat-square)](./LICENSE)
 
-[Explore the visual library](https://h3-field-notes-production.up.railway.app/) · [中文说明](./README.zh-CN.md) · [Case catalog](./CATALOG.md) · [Contribute](./CONTRIBUTING.md)
+[Explore the English library](https://h3-field-notes-production.up.railway.app/en/) · [Toolkit](https://h3-field-notes-production.up.railway.app/en/toolkit/) · [FAQ](https://h3-field-notes-production.up.railway.app/en/faq/) · [中文说明](./README.zh-CN.md) · [Contribute](./CONTRIBUTING.md)
 
 </div>
 
@@ -17,15 +17,14 @@
 
 Awesome MiniMax H3 is an open, source-attributed library for **MiniMax H3**, also searched as **Hailuo 3.0**. It organizes public AI video generation examples into reusable prompt patterns for text-to-video, first/last-frame video generation, multimodal reference video editing, synchronized audio, camera movement, dialogue, and character consistency.
 
-The project combines a searchable visual website, Prompt-as-Code templates, a machine-readable dataset, and a browser-first X discovery workflow. Every public case keeps its original source and prompt provenance; uncertain discoveries stay in a review queue.
+The project combines a case-first bilingual website, a machine-readable dataset, and a browser-first X discovery workflow. Every public case keeps its original source and prompt provenance; uncertain discoveries stay in a review queue.
 
 ## What is included
 
 | Resource | Purpose |
 | --- | --- |
-| [Visual case library](https://h3-field-notes-production.up.railway.app/) | Filter MiniMax H3 examples by mode, category, visual style, scene, and keyword |
+| [English visual case library](https://h3-field-notes-production.up.railway.app/en/) | Watch and filter MiniMax H3 examples by mode, category, visual style, scene, and keyword |
 | [`data/cases.json`](./data/cases.json) | Source-attributed, structured MiniMax H3 video prompts and metadata |
-| [`data/templates.json`](./data/templates.json) | Reusable Prompt-as-Code patterns derived from verified cases |
 | [`CATALOG.md`](./CATALOG.md) | Lightweight GitHub-native case index |
 | [`agents/skills/minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) | Agent Skill for retrieving and adapting prompt patterns |
 | [`docs/DISCOVERY_WORKFLOW.md`](./docs/DISCOVERY_WORKFLOW.md) | Browser-based X discovery, deduplication, review, and attribution rules |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 # Awesome MiniMax H3
 
-### MiniMax H3 / 海螺 Hailuo 3.0 视频案例、提示词模板与可复现工作流
+### MiniMax H3 / 海螺 Hailuo 3.0 视频案例、提示词记录与可复现工作流
 
-[在线案例库](https://h3-field-notes-production.up.railway.app/) · [English](./README.md) · [案例目录](./CATALOG.md) · [参与贡献](./CONTRIBUTING.md)
+[在线案例库](https://h3-field-notes-production.up.railway.app/) · [工具链](https://h3-field-notes-production.up.railway.app/toolkit/) · [常见问题](https://h3-field-notes-production.up.railway.app/faq/) · [English](./README.md) · [参与贡献](./CONTRIBUTING.md)
 
 </div>
 
@@ -12,7 +12,7 @@
 
 Awesome MiniMax H3 是一个带来源追踪的开源 AI 视频提示词案例库，覆盖 **MiniMax H3**、**Hailuo 3.0**、文字生视频、首尾帧视频、全模态参考视频、视频编辑、原生音频、运镜、对白、口型与角色一致性等高意图检索词。
 
-项目由四部分组成：可筛选的网站、Prompt-as-Code 模板、机器可读数据，以及使用 Mac 登录态浏览器自动发现 X 案例的审核工作流。公开案例都保留原始来源和提示词来源类型；不确定内容只进入候选队列，不会超时自动发布。
+项目由三部分组成：案例优先的中英双语网站、机器可读数据，以及使用 Mac 登录态浏览器自动发现 X 案例的审核工作流。公开案例都保留原始来源和提示词来源类型；不确定内容只进入候选队列，不会超时自动发布。
 
 当前共有 25 个公开案例：3 个 MiniMax 官方可复现案例，以及 22 个经人工批准的 X 社区案例，覆盖完整提示词、本地 ComfyUI 性能测试、图片与多模态参考、模型对比、音乐视频、多镜头短片、原生音频和后期工作流。X 案例通过官方嵌入播放器在站内直接播放；确实无法嵌入时，可在留存许可记录后启用自托管兜底。
 
@@ -22,7 +22,6 @@ Awesome MiniMax H3 是一个带来源追踪的开源 AI 视频提示词案例库
 | --- | --- |
 | [可视化案例库](https://h3-field-notes-production.up.railway.app/) | 按生成模式、分类、风格、场景和关键词筛选 |
 | [`data/cases.json`](./data/cases.json) | 带来源与核验状态的结构化视频案例和提示词记录 |
-| [`data/templates.json`](./data/templates.json) | 从已核验案例提炼的可复用提示词模板 |
 | [`CATALOG.md`](./CATALOG.md) | GitHub 原生案例索引 |
 | [`agents/skills/minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) | 用于检索和改写提示词的 Agent Skill |
 

--- a/data/cases.json
+++ b/data/cases.json
@@ -6,6 +6,7 @@
     "model": "MiniMax H3 Base FL2VA",
     "mode": "T2VA",
     "summary": "从星舰舰桥的中广景切至舰长面部特写，以原生立体声同步表现舰队跃迁、空间冲击与骤然安静的余波。",
+    "summaryEn": "Moves from a medium-wide view of a starship bridge to a close-up of the captain, using native stereo audio to synchronize the fleet jump, spatial shock, and the suddenly quiet aftermath.",
     "prompt": "[Shot 1] Cinematic medium-wide shot, pushing in slowly. A female captain stands in the dimly lit bridge of a starship, silhouetted against a massive observation window. Outside, an armada of dreadnoughts hovers against a deep purple nebula as their rear thrusters begin to glow blue. [Shot 2] At 00:04.500, cut to a close-up of the captain's face as the bridge shakes strongly. A blinding flash floods the window when the fleet jumps to hyperspace. The force jolts the bridge; she staggers, braces, then slowly closes her eyes as the light fades. Sound: low ship hum, escalating electronic whine, bass-heavy boom, metallic rattling, then a hollow room tone. Music: mournful French horn and sustained strings building to a peak before snapping into silence.",
     "sourceUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/scripts/readme/reproducible-768p-t2va-request.sh",
     "sourceLabel": "MiniMax 官方复现脚本",
@@ -46,6 +47,7 @@
     "model": "MiniMax H3 Base FL2VA",
     "mode": "FL2VA",
     "summary": "以拉面首帧为约束，通过缓慢焦点转移让前景蒸汽虚化、背景家庭成员逐渐清晰，考验景深和群像动作。",
+    "summaryEn": "Uses a ramen image as the opening-frame constraint, then gradually racks focus so the foreground steam softens while the family in the background comes into view, testing depth of field and ensemble motion.",
     "prompt": "Reference Picture 1 fully at 0.00 seconds. Hold a perfectly static cinematic shot in a traditional Japanese dining room. Begin with a blue-and-white ceramic bowl of ramen in crisp foreground focus: golden broth, noodles, chashu, scallions and nori. Thick white steam rises continuously. Gradually rack focus deeper into the room so the bowl becomes soft while a family of seven around the table resolves into sharp detail. Family members smile, gesture, use chopsticks and converse naturally as steam forms a translucent veil. Sound: broth hiss, ceramic and chopstick clinks, clothing movement. Music: gentle acoustic guitar with subtle koto.",
     "sourceUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/scripts/readme/reproducible-768p-fl2va-request.sh",
     "sourceLabel": "MiniMax 官方复现脚本",
@@ -87,6 +89,7 @@
     "model": "MiniMax H3 Base Ref2VA",
     "mode": "Ref2VA",
     "summary": "同时引用视频、原背景音乐和额外人声音色，让角色新增英语对白并保持身份、服装、镜头与环境稳定。",
+    "summaryEn": "References a source video, its original background music, and an additional voice timbre to add English dialogue while preserving character identity, wardrobe, framing, and setting.",
     "prompt": "Edit Video 1 while preserving the young man with wavy blonde hair, bright pink suit, white shirt and the black lamb in his arms. Preserve the original framing, golden-hour pasture and background lambs. Reuse Audio 1 as background music and reference the calm male timbre of Audio 2. Animate the subject's mouth naturally as he says: ‘Follow the wind, live free. Leave worries behind, enjoy the moment.’ When speech ends, his lips meet in a relaxed smile; he looks toward the horizon and gently strokes the lamb while the camera holds.",
     "sourceUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/scripts/readme/reproducible-768p-ref2va-request.sh",
     "sourceLabel": "MiniMax 官方复现脚本",
@@ -128,6 +131,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "T2VA",
     "summary": "1950 年代餐厅里，碰撞飞散的咖啡、餐盘与食物在空中冻结，镜头环绕后让整个世界逆向复原；原帖公开了分段运镜与动作提示词，但展示视频为 15 秒、提示词时间轴为 30 秒。",
+    "summaryEn": "Inside a 1950s diner, coffee, dishes, and food freeze in mid-air after a collision. The camera circles the scene before the entire world rewinds to its starting state. The original post includes a segmented camera-and-action prompt, although the displayed video lasts 15 seconds while the prompt timeline spans 30 seconds.",
     "prompt": "Photorealistic cinematic 1950s American diner, chrome stools, red vinyl, neon glow and checkerboard floor, shot with modern lived-in realism and soft natural window light. Subtle handheld texture, warm practicals, rich period detail, heavy film grain. 0-4s: [Medium Wide] A striking young woman in her early 20s sits alone at the counter, calm and slightly amused, slowly sipping a tall thick milkshake through a straw. Behind her a young waitress in classic uniform approaches with a tray of eggs and bacon in one hand and a full glass coffee pot in the other. An older lady starts rising from a nearby booth. 4-8s: [Dynamic Tracking] The older lady collides hard into the waitress. Tray, plate, eggs, bacon and coffee pot explode upward in chaotic slow motion. Coffee erupts into long liquid ribbons and perfect suspended droplets. Camera immediately begins a smooth continuous orbit around the impact. Time locks completely at the peak of the spill. Every face freezes in pure shock. Only the girl at the counter keeps moving, completely unfazed. 8-17s: [Slow 360° Orbital] Camera glides in a full elegant orbit through the frozen diner. Coffee hangs in mid-air as glassy ribbons and spheres with perfect volume and surface tension. Bacon strips, eggs and the spinning tray float weightlessly. Patrons and waitress remain locked in startled expressions. The girl at the counter takes one slow, deliberate sip, eyes half-lidded, almost bored, while the entire frozen world (except her) begins an elegant reverse: every droplet, every piece of food and every person rewinds smoothly back to the exact starting positions. 17-24s: [Medium Shot] Rewind lands perfectly. Waitress stands balanced again with tray and coffee pot. The girl lifts her eyes, raises two fingers in a small casual gesture and softly calls the waitress by name. The waitress turns toward her just before the older lady begins to stand, completely avoiding the collision. A tiny private smile crosses the girl’s face. 24-30s: [Extreme Close-Up] Hard cut to her face as she takes one last slow sip. Soft knowing smile, eyes almost closed in quiet satisfaction, like she has done this a hundred times. Shallow depth of field, creamy bokeh of the neon diner behind her. Photorealistic, ultra-detailed fluid physics, perfect motion blur only on moving elements, stable characters, cinematic lighting, heavy natural film grain, no artifacts, movie-level temporal coherence, high rewatch value.",
     "sourceUrl": "https://x.com/icreat_ai/status/2085297962977227011",
     "sourceLabel": "X 原帖 · @icreat_ai",
@@ -169,6 +173,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "FL2VA",
     "summary": "创作者使用图片确定视觉风格，再配合文字提示复刻小学课本场景，并以贝多芬《月光曲》从平静、汹涌到归于平静的情绪变化组织 15 秒视频。",
+    "summaryEn": "The creator used an image to establish the visual style and a text prompt to recreate a primary-school textbook scene, structuring the 15-second video around the emotional arc of Beethoven’s Moonlight Sonata—from calm to turbulent and back to calm.",
     "prompt": "原帖未公开完整提示词。公开信息：使用图片定风格并配合文字提示词，复刻小学课本场景；音乐情绪参考贝多芬《月光曲》，从平静到汹涌再归于平静。",
     "sourceUrl": "https://x.com/Yangtze_Seventh/status/2085318072903299536",
     "sourceLabel": "X 原帖 · @Yangtze_Seventh",
@@ -200,7 +205,8 @@
     ],
     "promptProvenance": "unknown",
     "sourceType": "x",
-    "verified": false
+    "verified": false,
+    "promptEn": "The original post does not disclose the full prompt. Public details: an image established the visual style, while a text prompt recreated a primary-school textbook scene. The musical arc follows Beethoven's Moonlight Sonata from calm to turbulence and back to calm."
   },
   {
     "id": "x-tapehead-composition-mv",
@@ -209,6 +215,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "Unknown",
     "summary": "一支由 Suno 音乐、Midjourney 视觉素材和 MiniMax H3 视频生成组合而成的长篇 MV。创作者强调 H3 对对象分层与提示词遵循的表现；具体生成模式和单镜头提示词未公开。",
+    "summaryEn": "A long-form music video built from Suno music, Midjourney visuals, and MiniMax H3 video generation. The creator highlights H3’s object layering and prompt adherence, but does not disclose the exact generation mode or shot-level prompts.",
     "prompt": "原帖未公开完整提示词。公开工作流：Music — Suno；Visual — Midjourney；Video Generation — MiniMax H3。创作者称 H3 擅长把对象作为图层处理并能较好遵循提示词。",
     "sourceUrl": "https://x.com/tapehead_Lab/status/2085304883847258179",
     "sourceLabel": "X 原帖 · @tapehead_Lab",
@@ -240,7 +247,8 @@
     ],
     "promptProvenance": "unknown",
     "sourceType": "x",
-    "verified": false
+    "verified": false,
+    "promptEn": "The original post does not disclose the full prompt. Published workflow: music with Suno, visuals with Midjourney, and video generation with MiniMax H3. The creator highlights object layering and prompt adherence."
   },
   {
     "id": "x-pollo-commercial-comparison",
@@ -249,6 +257,7 @@
     "model": "MiniMax H3 与 Seedance 2.0 对比",
     "mode": "T2VA",
     "summary": "在 Pollo AI 中使用相同提示词和设置，对比 MiniMax H3 与 Seedance 2.0 的商业广告输出。创作者认为 H3 更自然、精致，另一模型更强调电影化视觉冲击。",
+    "summaryEn": "Uses the same prompt and settings in Pollo AI to compare commercial outputs from MiniMax H3 and Seedance 2.0. The creator describes H3 as more natural and polished, while the other model places greater emphasis on cinematic visual impact.",
     "prompt": "原帖说明两种模型使用相同提示词与设置，但未公开提示词正文。内容为品牌商业广告对比；原帖标记为付费合作。",
     "sourceUrl": "https://x.com/__spence_r/status/2085281251183747482",
     "sourceLabel": "X 原帖 · @__spence_r",
@@ -280,7 +289,8 @@
     ],
     "promptProvenance": "unknown",
     "sourceType": "x",
-    "verified": false
+    "verified": false,
+    "promptEn": "The post states that both models used the same prompt and settings, but does not publish the prompt text. The case is a sponsored comparison of branded commercial outputs."
   },
   {
     "id": "x-mayii-ugc-commercial",
@@ -289,6 +299,7 @@
     "model": "MiniMax H3 + HyperFrames（创作者标注）",
     "mode": "Unknown",
     "summary": "面向不同国家与内容平台制作的 AI UGC 商品短片工作流，创作者明确说明商业化版本主要由 HyperFrames 与 MiniMax H3 配合完成；两者的具体职责仍待拆解。",
+    "summaryEn": "An AI UGC product-video workflow tailored to different countries and content platforms. The creator states that the commercial version mainly combines HyperFrames with MiniMax H3, although the division of responsibilities between them remains undocumented.",
     "prompt": "原帖未公开完整提示词。公开信息：围绕同一款商品，参考 IG Reels 与小红书种草视频风格，为不同国家和平台受众制作短片；商业化版本主要使用 HyperFrames 与 MiniMax H3。",
     "sourceUrl": "https://x.com/Mayii0205/status/2085305063405220214",
     "sourceLabel": "X 原帖 · @Mayii0205",
@@ -320,7 +331,8 @@
     ],
     "promptProvenance": "unknown",
     "sourceType": "x",
-    "verified": false
+    "verified": false,
+    "promptEn": "The original post does not disclose the full prompt. It describes adapting one product into IG Reels and Xiaohongshu-style seeding videos for audiences in different countries, mainly using HyperFrames and MiniMax H3."
   },
   {
     "id": "x-soylab-person-replacement",
@@ -329,6 +341,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "Ref2VA",
     "summary": "基于 ComfyUI 的人物替换短片实验。原帖明确标注 MiniMax H3，但没有公开提示词、参考输入或节点配置，并包含受版权保护角色的视觉引用。",
+    "summaryEn": "A ComfyUI-based person-replacement video experiment. The original post explicitly identifies MiniMax H3 but provides no prompt, reference inputs, or node configuration, and includes a visual reference to a copyrighted character.",
     "prompt": "原帖未公开完整提示词。公开描述仅为：MiniMax H3 — Test for Replacing a Person；标签包括 ComfyUI、MiniMax、H3 与 Joker。输入类型依据任务描述暂归为参考图像与视频，尚未由创作者确认。",
     "sourceUrl": "https://x.com/soy_lab/status/2085305126001225909",
     "sourceLabel": "X 原帖 · @soy_lab",
@@ -359,7 +372,8 @@
     ],
     "promptProvenance": "unknown",
     "sourceType": "x",
-    "verified": false
+    "verified": false,
+    "promptEn": "The original post only describes this as a MiniMax H3 person-replacement test and does not disclose the prompt, reference inputs, or ComfyUI configuration."
   },
   {
     "id": "x-yukyuk-h3-seedance-same-prompt",
@@ -368,6 +382,7 @@
     "model": "MiniMax H3 与 Seedance 2（创作者标注）",
     "mode": "Unknown",
     "summary": "YukYuk 使用相同提示词分别生成 MiniMax H3 与 Seedance 2 的 15 秒视频，用于观察两个模型的输出差异；原帖没有公开提示词正文。",
+    "summaryEn": "YukYuk generated separate 15-second videos with MiniMax H3 and Seedance 2 using the same prompt to compare their outputs. The original post does not disclose the prompt text.",
     "prompt": "原帖称两个模型使用同一提示词，但未公开提示词正文。",
     "sourceUrl": "https://x.com/YukYukID/status/2085553970702074050",
     "sourceLabel": "X 原帖 · @YukYukID",
@@ -410,7 +425,8 @@
       "durationSeconds": 15,
       "resolution": "not visible",
       "aspectRatio": "not visible"
-    }
+    },
+    "promptEn": "The post says both models used the same prompt, but does not publish the prompt text."
   },
   {
     "id": "x-melvin-comfyui-rtx3090-local",
@@ -419,6 +435,7 @@
     "model": "MiniMax H3 + ComfyUI（创作者标注）",
     "mode": "Unknown",
     "summary": "创作者在 RTX 3090 上通过 ComfyUI 本地生成 15 秒 H3 视频，公开输出为 864×480、耗时约 22 分钟，并肯定其提示词遵循能力。",
+    "summaryEn": "The creator generated a 15-second H3 video locally in ComfyUI on an RTX 3090. The published output is 864×480, took approximately 22 minutes to render, and was presented as a positive test of prompt adherence.",
     "prompt": "原帖未公开提示词正文，只说明仍在测试 prompts。",
     "sourceUrl": "https://x.com/melvindvivas/status/2085553403846078669",
     "sourceLabel": "X 原帖 · @melvindvivas",
@@ -461,7 +478,8 @@
       "durationSeconds": 15,
       "resolution": "864x480",
       "aspectRatio": "not visible"
-    }
+    },
+    "promptEn": "The post does not publish the prompt text and only notes that prompt testing was still in progress."
   },
   {
     "id": "x-coretan-eating-ramen-turbo-lora",
@@ -470,6 +488,7 @@
     "model": "MiniMax H3 Turbo LoRA（创作者标注）",
     "mode": "T2VA",
     "summary": "本地 Turbo LoRA 实验只使用作者公开的单句提示词“Eating Ramen”，测试人物吃拉面时手部、筷子与动作表现。",
+    "summaryEn": "This local Turbo LoRA experiment uses only the creator’s published one-line prompt, “Eating Ramen,” to test the character’s hands, chopsticks, and eating motion.",
     "prompt": "Eating Ramen",
     "sourceUrl": "https://x.com/core_tan/status/2085551748874449032",
     "sourceLabel": "X 原帖 · @core_tan",
@@ -521,6 +540,7 @@
     "model": "MiniMax H3 + Claude Code（创作者标注）",
     "mode": "Unknown",
     "summary": "创作者称 37 秒视频及声音均由 MiniMax H3 本地生成，并通过 Claude Code 一次完成；公开硬件为 Mac Studio M3 Ultra 256GB。",
+    "summaryEn": "The creator states that both the 37-second video and its audio were generated locally with MiniMax H3 in a single Claude Code run. The disclosed hardware is a Mac Studio with an M3 Ultra and 256 GB of memory.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/rsensui/status/2085551007631880347",
     "sourceLabel": "X 原帖 · @rsensui",
@@ -564,7 +584,8 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "audioClaim": "作者称音频与视频均由 MiniMax H3 本地生成"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-sada-hand-painted-blizzard",
@@ -573,6 +594,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "T2VA",
     "summary": "作者公开完整提示词，以纸上油画逐帧动画、12 fps 停格节奏、冰冷月光和暴风雪环境描绘一对母子在极端天气中求生。",
+    "summaryEn": "The creator publishes the full prompt for a frame-by-frame oil-on-paper animation with a 12 fps stop-motion cadence, cold moonlight, and a violent blizzard, depicting a mother and child struggling to survive extreme weather.",
     "prompt": "Visual Medium & Craft: Traditional frame-by-frame hand-painted oil-on-paper animation, physical 12 fps stop-motion cadence with deliberate frame holds and natural line jitter between frames. Raw brushstroke textures, strictly zero CGI, no 3D rendering, no digital interpolation, no game engine aesthetics. Cinematography & Lighting: Masterful cinematography in the style of Emmanuel Lubezki and Roger Deakins, shot with physical cine lenses and a classic 180° shutter blur. Lit exclusively by a single overhead light source: pale, freezing moonlight cutting through dense atmospheric haze. Strong contre-jour backlighting with the camera positioned on the shadow side. Uniform cold blue moonlight washes over skin, clothing, snow, and tree trunks, casting sharp cold rim lights on shoulders and hoods while keeping faces in soft shadow. Atmosphere & Environment: A violent, blinding blizzard with near-zero visibility (3 meters maximum), dissolving the background into a solid white fog wall. Gale-force horizontal winds whip thick snow and freezing fog through the frame. Deep snow quickly accumulates on garments. Exhaled breath instantly vaporizes and tears away in the wind. Characters & Emotion: A desperate mother and her frightened young child battling for survival, lost in the storm at the absolute limit of their endurance. The mother conceals her panic to protect her child, while the child cries openly in fear. Both lean heavily into the gale, squinting against the biting wind, shielding their faces with forearms and ducking into their collars. Technical Details: Color palette dominated by 60% snow-blue, 30% deep trunk-black, and 10% cold highlight accents. Strict physical realism with grounded weight, true inertia, and accurate contact shadows on snow. Dynamic compositional balance using the rule of thirds and golden ratio. Uncompromising continuity across all character designs, garments, and environmental assets. 8K IMAX aesthetic.",
     "sourceUrl": "https://x.com/sada_ai/status/2085547332880503134",
     "sourceLabel": "X 原帖 · @sada_ai",
@@ -628,6 +650,7 @@
     "model": "Krea 2 + MiniMax H3（创作者标注）",
     "mode": "FL2VA",
     "summary": "使用 Krea 2 生成的图片作为 H3 视频输入，形成一条适合夜间批量渲染的图片生视频工作流；原帖没有公开提示词。",
+    "summaryEn": "Uses an image generated with Krea 2 as the input for H3, creating an image-to-video workflow suitable for overnight batch rendering. The original post does not disclose the prompt.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/tmaiaroto/status/2085543978611736973",
     "sourceLabel": "X 原帖 · @tmaiaroto",
@@ -670,7 +693,8 @@
       "durationSeconds": 5,
       "resolution": "not visible",
       "aspectRatio": "not visible"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-opener-deep-sea-ui-comparison",
@@ -679,6 +703,7 @@
     "model": "MiniMax H3 与 Seedance 2.5 对比",
     "mode": "FL2VA",
     "summary": "作者用同一份完整提示词比较 H3 与 Seedance 2.5：以首帧固定深海百科 UI，只允许光标、主标题和左侧生物变化，并精确编排音效与负面约束。",
+    "summaryEn": "Uses the same full prompt to compare H3 with Seedance 2.5: a first-frame-locked deep-sea encyclopedia interface in which only the cursor, main title, and creature in the left panel may change, with precisely timed audio and extensive negative constraints.",
     "prompt": "[FORMAT]\nCreate a 15-second, 16:9 interactive deep-sea creature encyclopedia video. One continuous locked-screen shot.\n\n[ASSETS]\nUse Image 1 as the exact opening frame and strict visual reference. Treat the entire interface and the complete right-side creature list as an immutable frozen background plate. All thumbnails, creatures, names, card positions, colors, and details on the right must remain pixel-stable and identical to Image 1 in every frame.\n\n[IDENTITY]\nPreserve exactly: the ‘CELESTIAL BESTIARY ARCHIVE’ header, pearl-white and ocean-blue palette, silver ornamental borders, large left display panel, complete right-side card grid, bottom navigation bar, navy typography, existing creature names, translucent crystalline materials, and original spacing. Each main creature must match its original card design without hybridization.\n\n[BEATS]\n[0–2.5 seconds] One white cursor touches LUMINARAY’s wing inside the large left panel. LUMINARAY blinks, chirps, and a constellation glow travels across its wings. Nothing on the right changes.\n[2.5–5 seconds] The cursor clicks the static AURORUNA card. Do not animate or highlight the card. Only the creature inside the left panel changes to AURORUNA. The main title crossfades in place to ‘AURORUNA.’ The cursor circles its bell; AURORUNA follows it and releases a soft stardust pulse.\n[5–7.5 seconds] The cursor clicks the static CORALUMI card. The card and every other right-side thumbnail remain completely unchanged. Only the left-panel creature and main title update to CORALUMI. Three taps on its shell create three small localized lights and delicate chimes.\n[7.5–10.5 seconds] The cursor clicks the static GLOWFIN card. Only the left-panel creature and main title update to GLOWFIN. Two pokes on its lure make it squeak, track the cursor with its eyes, and intensify its bioluminescent glow.\n[10.5–15 seconds] A third poke triggers GLOWFIN’s adult transformation, strictly contained inside the left panel. Preserve its navy scales, round eyes, sharp teeth, fins, and forehead lure. The adult GLOWFIN growls, lunges forward, snaps at the cursor, then returns to idle. The title remains ‘GLOWFIN.’ The right-side list remains identical to the opening frame.\n\n[CAMERA]\nLocked front-facing screen view. No pan, zoom, tilt, shake, crop, perspective shift, parallax, or depth-of-field change. Use exactly one cursor.\n\n[LIGHT]\nMaintain the original pearl-white UI illumination, cool underwater blues, silver reflections, and luminous fantasy glow. Bioluminescent effects must remain clipped inside the large left display panel.\n\n[EDIT]\nNo cuts. Only three elements may change: the single cursor, the main title, and the creature inside the large left panel. Freeze every other UI pixel. The entire right-side card grid is a protected static 2D plate, not a group of animated objects. Main titles crossfade in place over 0.2 seconds, remain still until the next click, and exit only through opacity. No sliding, scaling, bouncing, re-lettering, or layout movement.\n\n[AUDIO]\nAudio: quiet deep-sea ambience, soft UI clicks, crystalline creature chirps, stardust shimmer, three shell chimes, two angler squeaks, a low maturation rumble, one aquatic growl, and a sharp bite snap. BGM: an original 15-second cue, 65% mystical underwater ambient and 35% playful digital fantasy. Glass harmonics, submerged synth pads, and soft sonar pulses. Build gently after 10.5 seconds and end with one humorous muted thump. Do not imitate an existing melody.\n\n[NEGATIVE]\nNever alter, animate, replace, redraw, relabel, reorder, highlight, morph, or regenerate any creature thumbnail or card on the right side. No card creature may blink, move, transform, disappear, swap places, or become the currently selected creature. Do not change any right-side card name, illustration, border, color, position, scale, spacing, or selection state. Do not propagate the left-panel transformation into the card grid. No interface distortion, panel movement, duplicate cursors, extra creatures, extra buttons, new text, subtitles, watermarks, logos, or stickers. Do not introduce Chinese text, garbled characters, misspellings, or incorrect creature names. No hybrid anatomy, uncontrolled morphing, full-screen particles, or effects escaping the left panel. Never a slideshow.",
     "sourceUrl": "https://x.com/opener_ai/status/2085542413729513534",
     "sourceLabel": "X 原帖 · @opener_ai",
@@ -735,6 +760,7 @@
     "model": "MiniMax H3（创作者标注）",
     "mode": "Unknown",
     "summary": "一支时长约 2 分 17 秒的 MiniMax H3 音乐视频实验；原帖明确模型来源，但没有公开提示词或输入素材。",
+    "summaryEn": "A MiniMax H3 music-video experiment lasting approximately 2 minutes and 17 seconds. The original post identifies the model but does not disclose the prompt or input assets.",
     "prompt": "原帖未公开提示词正文或输入素材。",
     "sourceUrl": "https://x.com/megurosumi/status/2085535070102884729",
     "sourceLabel": "X 原帖 · @megurosumi",
@@ -777,7 +803,8 @@
       "durationSeconds": 137,
       "resolution": "not visible",
       "aspectRatio": "not visible"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text or input assets."
   },
   {
     "id": "x-o685463-comfyui-12step-tests",
@@ -786,6 +813,7 @@
     "model": "MiniMax H3 + ComfyUI（创作者标注）",
     "mode": "Unknown",
     "summary": "三组各 5 秒的本地 ComfyUI 测试，以速度优先的 12 步设置观察 H3 的流体与毛发表现；作者指出低步数下这些细节仍较吃力。",
+    "summaryEn": "Three local ComfyUI tests, each lasting five seconds, use speed-first 12-step settings to examine H3’s handling of fluids and fur. The creator notes that both remain challenging at low step counts.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/O685463/status/2086345324164161598",
     "sourceLabel": "X 原帖 · @O685463",
@@ -831,7 +859,8 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "generationSettings": "12 steps; local ComfyUI"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-sepisheim-ref2va-character-sheet",
@@ -840,6 +869,7 @@
     "model": "MiniMax H3 Ref2VA（创作者标注）",
     "mode": "Ref2VA",
     "summary": "使用 ChatGPT 生成角色表作为参考输入，测试 H3 Ref2VA 的角色一致性；公开参数包括 RTX 4070、576×832、24 fps、5 秒和约 225 秒生成时间。",
+    "summaryEn": "Uses a character sheet generated with ChatGPT as the reference input for an H3 Ref2VA consistency test. Published parameters include an RTX 4070, 576×832 resolution, 24 fps, a five-second duration, and an approximately 225-second generation time.",
     "prompt": "原帖未公开提示词正文，只公开了保持画风描述简洁的经验。",
     "sourceUrl": "https://x.com/sep_is_heim/status/2086344253496766502",
     "sourceLabel": "X 原帖 · @sep_is_heim",
@@ -886,7 +916,8 @@
       "aspectRatio": "portrait",
       "fps": 24,
       "generationSettings": "RTX 4070; SageAttention; Spectrum; FirstBlockCache; 225 seconds"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text. It only notes that concise style descriptions worked better for this character-sheet consistency test."
   },
   {
     "id": "x-aion-flight-2k-astra-4k",
@@ -895,6 +926,7 @@
     "model": "MiniMax H3 + Astra（创作者标注）",
     "mode": "Unknown",
     "summary": "创作者先用 MiniMax H3 生成 2K 飞行场景，再使用 Astra 放大至 4K，展示生成与后期超分辨率串联的工作流。",
+    "summaryEn": "The creator first generates a 2K flight scene with MiniMax H3 and then upscales it to 4K with Astra, demonstrating a workflow that connects generation with post-production super-resolution.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/AION_2077/status/2086341354469441828",
     "sourceLabel": "X 原帖 · @AION_2077",
@@ -939,7 +971,8 @@
       "resolution": "2K H3 output, upscaled to 4K",
       "aspectRatio": "not visible",
       "postProcessing": "Astra upscale"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-toyxyz-i2v-turbo-lora",
@@ -948,6 +981,7 @@
     "model": "MiniMax H3 Turbo LoRA + ComfyUI（创作者标注）",
     "mode": "FL2VA",
     "summary": "一条 10 秒的 MiniMax H3 图片生视频 Turbo LoRA 测试，明确使用 ComfyUI；原帖未公开参考图细节或提示词。",
+    "summaryEn": "A 10-second MiniMax H3 image-to-video Turbo LoRA test created in ComfyUI. The original post does not disclose the reference-image details or prompt.",
     "prompt": "原帖未公开提示词正文或参考图说明。",
     "sourceUrl": "https://x.com/toyxyz3/status/2086339956755329363",
     "sourceLabel": "X 原帖 · @toyxyz3",
@@ -992,7 +1026,8 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "generationSettings": "I2V Turbo LoRA; ComfyUI"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text or explain the reference image."
   },
   {
     "id": "x-cia0-omni-nine-reference-film",
@@ -1001,6 +1036,7 @@
     "model": "MiniMax H3 Omni（创作者标注）",
     "mode": "Ref2VA",
     "summary": "H3 Omni 在一支 15 秒 AI 电影预告中同时处理九张参考图，并测试细节文字渲染。作者只透露提示词约 3,943 个中文字符，没有公开正文。",
+    "summaryEn": "H3 Omni processes nine reference images simultaneously in a 15-second AI film trailer while also testing fine-detail text rendering. The creator only discloses that the prompt contains approximately 3,943 Chinese characters, without publishing its contents.",
     "prompt": "原帖只公开提示词长度为 3,943 个中文字符，没有展示提示词正文。",
     "sourceUrl": "https://x.com/Cia0_exe/status/2086339725875699927",
     "sourceLabel": "X 原帖 · @Cia0_exe",
@@ -1047,7 +1083,8 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "referenceImageCount": 9
-    }
+    },
+    "promptEn": "The creator only discloses that the prompt contains 3,943 Chinese characters and does not publish its contents."
   },
   {
     "id": "x-nsitnov-white-camellia-local-film",
@@ -1056,6 +1093,7 @@
     "model": "MiniMax H3 + Qwen Image 3 Pro + ElevenLabs",
     "mode": "Unknown",
     "summary": "《The White Camellia》由六段 15 秒 H3 镜头组成，并结合 Qwen Image 3 Pro 与 ElevenLabs，在 RTX Pro 6000 96GB 上完成本地制作。",
+    "summaryEn": "The White Camellia comprises six 15-second H3 shots and combines Qwen Image 3 Pro with ElevenLabs. It was produced locally on an RTX Pro 6000 with 96 GB of memory.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/NsitnovSitnov/status/2086338366946123992",
     "sourceLabel": "X 原帖 · @NsitnovSitnov",
@@ -1103,7 +1141,8 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "workflow": "6 × 15-second H3 clips; Qwen Image 3 Pro; ElevenLabs; local RTX Pro 6000 96GB"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-aiconia-i2v-larry-turbo-h3-sage",
@@ -1112,6 +1151,7 @@
     "model": "MiniMax H3 + Larry Turbo + H3 Sage",
     "mode": "FL2VA",
     "summary": "RTX 4070 上的 1MP、10 秒 I2V 加速测试，生成耗时 11 分 12 秒，并追加放大和插帧；作者同时公开了脸部块状噪点与语音较弱等缺陷。",
+    "summaryEn": "A 1 MP, 10-second I2V acceleration test on an RTX 4070 took 11 minutes and 12 seconds, followed by upscaling and frame interpolation. The creator also documents blocky facial artifacts and weak speech generation.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/AiPhotorealGirl/status/2086336598539747535",
     "sourceLabel": "X 原帖 · @AiPhotorealGirl",
@@ -1156,7 +1196,8 @@
       "resolution": "1MP before upscale",
       "aspectRatio": "not visible",
       "generationSettings": "RTX 4070; Larry Turbo + H3 Sage; 11m12s; upscale and frame interpolation"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   },
   {
     "id": "x-maki-motion-context-five-scene-mv",
@@ -1165,6 +1206,7 @@
     "model": "MiniMax H3 + HyperFrames（创作者标注）",
     "mode": "Unknown",
     "summary": "通过 Motion Context 连锁生成五个场景，把 H3 生成的语音作为音乐，再用 HyperFrames 叠加随节拍运动的歌词，完成约 29 秒的雨中东京 MV。",
+    "summaryEn": "Motion Context chains five scenes together, uses H3-generated vocals as the music, and adds beat-synchronized lyrics with HyperFrames to create an approximately 29-second music video set in rainy Tokyo.",
     "prompt": "原帖未公开提示词正文。",
     "sourceUrl": "https://x.com/hAru_mAki_ch/status/2086334052639142176",
     "sourceLabel": "X 原帖 · @hAru_mAki_ch",
@@ -1213,6 +1255,7 @@
       "resolution": "not visible",
       "aspectRatio": "not visible",
       "workflow": "H3 Motion Context across 5 scenes; H3-generated voice; HyperFrames synced lyrics"
-    }
+    },
+    "promptEn": "The original post does not publish the prompt text."
   }
 ]

--- a/data/schema.json
+++ b/data/schema.json
@@ -3,15 +3,19 @@
   "title": "H3 Field Notes case",
   "type": "object",
   "required": [
-    "id", "title", "model", "mode", "prompt", "sourceUrl", "author", "posterUrl",
+    "id", "title", "titleEn", "summary", "summaryEn", "model", "mode", "prompt", "sourceUrl", "author", "posterUrl",
     "category", "styles", "scenes", "inputTypes", "promptProvenance", "verified"
   ],
   "properties": {
     "id": { "type": "string", "minLength": 3 },
     "title": { "type": "string" },
+    "titleEn": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "summaryEn": { "type": "string", "minLength": 1 },
     "model": { "type": "string" },
     "mode": { "enum": ["T2VA", "FL2VA", "Ref2VA", "Unknown"] },
     "prompt": { "type": "string" },
+    "promptEn": { "type": "string", "minLength": 1 },
     "sourceUrl": { "type": "string", "format": "uri" },
     "posterUrl": { "type": "string", "minLength": 1 },
     "author": { "type": "string" },

--- a/index.html
+++ b/index.html
@@ -4,64 +4,45 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0b09" />
-    <meta name="description" content="MiniMax H3 / Hailuo 3.0 AI 视频案例、提示词模板、部署教程与 ComfyUI 工具链。收录 H3 Skills、Turbo LoRA、长视频续接和音视频工作流。" />
-    <meta name="keywords" content="MiniMax H3,Hailuo 3.0,海螺 AI,MiniMax H3 部署,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio,AI video generation,video prompts,视频提示词,T2VA,FL2VA,Ref2VA" />
+    <meta name="description" content="可筛选、可追溯的 MiniMax H3 / Hailuo 3.0 视频案例库，保留视频封面、提示词记录、输入方式与原始来源。" />
+    <meta name="keywords" content="MiniMax H3 视频案例,Hailuo 3.0,海螺 3.0,AI 视频提示词,T2VA,FL2VA,Ref2VA" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-video-preview:-1" />
     <link rel="canonical" href="https://h3-field-notes-production.up.railway.app/" />
     <link rel="alternate" hreflang="zh-CN" href="https://h3-field-notes-production.up.railway.app/" />
+    <link rel="alternate" hreflang="en" href="https://h3-field-notes-production.up.railway.app/en/" />
     <link rel="alternate" hreflang="x-default" href="https://h3-field-notes-production.up.railway.app/" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="H3 Field Notes" />
-    <meta property="og:title" content="Awesome MiniMax H3 — Hailuo 3.0 视频提示词案例库" />
-    <meta property="og:description" content="可筛选、可追溯的 MiniMax H3 视频案例，以及 Skills、Turbo LoRA、ComfyUI 部署和音视频工作流。" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:title" content="MiniMax H3 视频案例库 — H3 Field Notes" />
+    <meta property="og:description" content="可筛选、可追溯的 MiniMax H3 / Hailuo 3.0 视频案例库，保留视频封面、提示词记录、输入方式与原始来源。" />
     <meta property="og:url" content="https://h3-field-notes-production.up.railway.app/" />
     <meta property="og:image" content="https://h3-field-notes-production.up.railway.app/og-image.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Awesome MiniMax H3 / Hailuo 3.0" />
-    <meta name="twitter:description" content="Curated MiniMax H3 AI video prompts, examples, templates, and reproducible workflows." />
+    <meta name="twitter:title" content="MiniMax H3 视频案例库 — H3 Field Notes" />
+    <meta name="twitter:description" content="可筛选、可追溯的 MiniMax H3 / Hailuo 3.0 视频案例库，保留提示词记录与原始来源。" />
     <meta name="twitter:image" content="https://h3-field-notes-production.up.railway.app/og-image.jpg" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
-        "name": "Awesome MiniMax H3 / Hailuo 3.0 Video Prompt Library",
+        "name": "MiniMax H3 视频案例库 — H3 Field Notes",
         "alternateName": "H3 Field Notes",
         "url": "https://h3-field-notes-production.up.railway.app/",
-        "description": "A source-attributed library of MiniMax H3 AI video examples, prompts, deployment guides, ComfyUI tools, and reproducible workflows.",
-        "inLanguage": ["zh-CN", "en"],
+        "description": "可筛选、可追溯的 MiniMax H3 / Hailuo 3.0 视频案例库，保留视频封面、提示词记录、输入方式与原始来源。",
+        "inLanguage": "zh-CN",
         "isPartOf": {
           "@type": "WebSite",
           "name": "H3 Field Notes",
           "url": "https://h3-field-notes-production.up.railway.app/"
         },
-        "about": ["MiniMax H3", "Hailuo 3.0", "AI video generation", "video prompt engineering", "ComfyUI", "Turbo LoRA"],
-        "hasPart": [
-          {
-            "@type": "SoftwareSourceCode",
-            "name": "MiniMax H3 official repository and Agent Skills",
-            "codeRepository": "https://github.com/MiniMax-AI/MiniMax-H3"
-          },
-          {
-            "@type": "SoftwareSourceCode",
-            "name": "MiniMax-H3 Turbo LoRA",
-            "url": "https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora"
-          },
-          {
-            "@type": "SoftwareSourceCode",
-            "name": "ComfyUI H3 Motion Context",
-            "codeRepository": "https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context"
-          },
-          {
-            "@type": "SoftwareSourceCode",
-            "name": "MiniMax H3 Audio T8",
-            "codeRepository": "https://github.com/T8mars/comfyui-minimax-h3-audio-T8"
-          }
-        ]
+        "about": ["MiniMax H3", "Hailuo 3.0", "AI 视频生成", "视频提示词"]
       }
     </script>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230a0b09'/%3E%3Cpath d='M14 16h8v12h20V16h8v32h-8V36H22v12h-8z' fill='%23d8ff3e'/%3E%3C/svg%3E" />
-    <title>Awesome MiniMax H3 — Hailuo 3.0 视频提示词案例库</title>
+    <title>MiniMax H3 视频案例库 — H3 Field Notes</title>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/build-seo-pages.mjs
+++ b/scripts/build-seo-pages.mjs
@@ -6,6 +6,138 @@ const dist = resolve(root, 'dist')
 const baseUrl = (process.env.PUBLIC_SITE_URL || 'https://h3-field-notes-production.up.railway.app').replace(/\/$/, '')
 const cases = JSON.parse(await readFile(resolve(root, 'data/cases.json'), 'utf8'))
 
+const locales = ['zh-CN', 'en']
+
+const pageDefinitions = [
+  {
+    id: 'catalog',
+    paths: { 'zh-CN': '/', en: '/en/' },
+    schemaType: 'CollectionPage',
+    copy: {
+      'zh-CN': {
+        title: 'MiniMax H3 视频案例库 — H3 Field Notes',
+        description: '可筛选、可追溯的 MiniMax H3 / Hailuo 3.0 视频案例库，保留视频封面、提示词记录、输入方式与原始来源。',
+        keywords: 'MiniMax H3 视频案例,Hailuo 3.0,海螺 3.0,AI 视频提示词,T2VA,FL2VA,Ref2VA',
+      },
+      en: {
+        title: 'MiniMax H3 Video Case Library — H3 Field Notes',
+        description: 'A searchable, source-attributed library of MiniMax H3 and Hailuo 3.0 video examples, prompt records, input modes, and original sources.',
+        keywords: 'MiniMax H3 video examples,Hailuo 3.0,AI video prompts,T2VA,FL2VA,Ref2VA',
+      },
+    },
+  },
+  {
+    id: 'toolkit',
+    paths: { 'zh-CN': '/toolkit/', en: '/en/toolkit/' },
+    schemaType: 'CollectionPage',
+    copy: {
+      'zh-CN': {
+        title: 'MiniMax H3 工具链与部署资源 — H3 Field Notes',
+        description: 'MiniMax H3 官方 Skills、Turbo LoRA、ComfyUI 长视频续接与音视频工作流的精选部署资源。',
+        keywords: 'MiniMax H3 部署,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio',
+      },
+      en: {
+        title: 'MiniMax H3 Toolkit and Deployment Resources — H3 Field Notes',
+        description: 'Curated MiniMax H3 resources for official Skills, Turbo LoRA acceleration, ComfyUI clip chaining, and audio-video workflows.',
+        keywords: 'MiniMax H3 deployment,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio',
+      },
+    },
+  },
+  {
+    id: 'faq',
+    paths: { 'zh-CN': '/faq/', en: '/en/faq/' },
+    schemaType: 'WebPage',
+    copy: {
+      'zh-CN': {
+        title: 'MiniMax H3 视频案例库常见问题 — H3 Field Notes',
+        description: '关于 MiniMax H3、Hailuo 3.0、视频生成模式、案例来源与人工审核流程的常见问题。',
+        keywords: 'MiniMax H3 常见问题,Hailuo 3.0,海螺 3.0,T2VA,FL2VA,Ref2VA,AI 视频案例',
+      },
+      en: {
+        title: 'MiniMax H3 Video Library FAQ — H3 Field Notes',
+        description: 'Frequently asked questions about MiniMax H3, Hailuo 3.0, video generation modes, case sources, and human review.',
+        keywords: 'MiniMax H3 FAQ,Hailuo 3.0,T2VA,FL2VA,Ref2VA,AI video examples',
+      },
+    },
+  },
+]
+
+const ui = {
+  'zh-CN': {
+    back: '返回 H3 Field Notes 案例库',
+    language: 'EN',
+    playerLabel: 'X 原帖播放器',
+    playerProvider: '媒体由 X 提供',
+    coverAlt: '视频封面',
+    embedLink: '载入 X 原帖视频',
+    connectingLabel: '连接中',
+    connectingTitle: '正在连接 X 播放器',
+    connectingDetail: '视频封面已就绪，播放器通常会在 2–8 秒内出现。',
+    slowLabel: '响应较慢',
+    slowTitle: 'X 响应较慢，仍在加载',
+    slowDetail: '网络或隐私设置可能延迟播放器；你可以继续等待。',
+    failedLabel: '载入失败',
+    failedTitle: '播放器加载失败',
+    failedDetail: '请重新加载，或直接在 X 打开原帖。',
+    retry: '重新加载',
+    fallback: '播放器受限时在 X 打开原帖',
+    mode: '生成模式',
+    model: '模型',
+    output: '输出',
+    tags: '标签',
+    provenance: '提示词来源',
+    promptHeading: 'MiniMax H3 提示词记录',
+    promptNotice: '提示词保留来源原文。',
+    source: '查看原始来源',
+    siteDescription: 'MiniMax H3 视频案例库',
+  },
+  en: {
+    back: 'Back to the H3 Field Notes case library',
+    language: 'ZH',
+    playerLabel: 'Original X post player',
+    playerProvider: 'Media provided by X',
+    coverAlt: 'video cover',
+    embedLink: 'Load the original X post video',
+    connectingLabel: 'CONNECTING',
+    connectingTitle: 'Connecting to the X player',
+    connectingDetail: 'The video cover is ready. The player usually appears within 2–8 seconds.',
+    slowLabel: 'SLOW RESPONSE',
+    slowTitle: 'X is responding slowly',
+    slowDetail: 'Network or privacy settings may delay the player. You can keep waiting.',
+    failedLabel: 'LOAD FAILED',
+    failedTitle: 'The player failed to load',
+    failedDetail: 'Reload the page or open the original post on X.',
+    retry: 'Reload',
+    fallback: 'Open the original post on X if the player is unavailable',
+    mode: 'Generation mode',
+    model: 'Model',
+    output: 'Output',
+    tags: 'Tags',
+    provenance: 'Prompt provenance',
+    promptHeading: 'MiniMax H3 prompt record',
+    promptNotice: 'Prompt text is shown in English; creator-verbatim English is preserved as published.',
+    source: 'View original source',
+    siteDescription: 'MiniMax H3 video case library',
+  },
+}
+
+const provenanceLabels = {
+  'zh-CN': {
+    'official-verbatim': '官方原文',
+    'official-adapted': '官方内容改写',
+    'creator-verbatim': '创作者原文',
+    reconstructed: '根据公开信息重建',
+    unknown: '来源未披露',
+  },
+  en: {
+    'official-verbatim': 'Official, verbatim',
+    'official-adapted': 'Official, adapted',
+    'creator-verbatim': 'Creator, verbatim',
+    reconstructed: 'Reconstructed from public information',
+    unknown: 'Not disclosed',
+  },
+}
+
 const escapeHtml = (value) => String(value)
   .replaceAll('&', '&amp;')
   .replaceAll('<', '&lt;')
@@ -13,112 +145,337 @@ const escapeHtml = (value) => String(value)
   .replaceAll('"', '&quot;')
   .replaceAll("'", '&#39;')
 
+const jsonForHtml = (value) => JSON.stringify(value).replaceAll('<', '\\u003c')
 const absolute = (url) => new URL(url, `${baseUrl}/`).href
 const isoDuration = (seconds) => `PT${seconds}S`
+const localeCode = (locale) => locale === 'en' ? 'en_US' : 'zh_CN'
+const otherLocale = (locale) => locale === 'en' ? 'zh-CN' : 'en'
+const casePath = (locale, id) => `${locale === 'en' ? '/en' : ''}/cases/${encodeURIComponent(id)}/`
 
-for (const item of cases) {
-  const canonical = `${baseUrl}/cases/${encodeURIComponent(item.id)}/`
+function assertLanguageIsolation(html, locale, path) {
+  if (locale === 'en' && /[\u3400-\u9fff]/u.test(html)) {
+    throw new Error(`English page ${path} contains CJK text; refusing to generate a mixed-language route.`)
+  }
+}
+
+function englishModel(model) {
+  return model
+    .replaceAll('（创作者标注）', ' (creator-labeled)')
+    .replace(/^MiniMax H3 与 (.+) 对比$/, 'MiniMax H3 vs $1')
+    .replaceAll(' 与 ', ' vs ')
+}
+
+function englishSourceLabel(item) {
+  if (item.sourceType === 'official') return 'MiniMax official reproduction script'
+  const handle = item.sourceUrl.match(/x\.com\/([^/]+)\/status/i)?.[1]
+  if (handle) return `Original X post · @${handle}`
+  return 'Original community source'
+}
+
+function englishAuthor(item) {
+  if (!/[\u3400-\u9fff]/u.test(item.author)) return item.author
+  const handle = item.sourceUrl.match(/x\.com\/([^/]+)\/status/i)?.[1]
+  return handle ? `@${handle}` : 'Community creator'
+}
+
+function englishOutputValue(value) {
+  if (value === '原帖') return 'As shown in the original post'
+  if (value === '原帖未标注') return 'Not specified in the original post'
+  return value
+}
+
+function localizedCase(item, locale) {
+  if (locale === 'zh-CN') {
+    return {
+      title: item.title,
+      summary: item.summary,
+      prompt: item.prompt,
+      author: item.author,
+      model: item.model,
+      sourceLabel: item.sourceLabel,
+      resolution: item.resolution,
+      aspectRatio: item.aspectRatio,
+      tags: item.tags,
+    }
+  }
+
+  if (!item.summaryEn) {
+    throw new Error(`Case ${item.id} is missing summaryEn; refusing to generate a mixed-language English page.`)
+  }
+  const prompt = item.promptEn ?? item.prompt
+  if (/[\u3400-\u9fff]/u.test(prompt)) {
+    throw new Error(`Case ${item.id} is missing an English prompt record; refusing to generate a mixed-language English page.`)
+  }
+
+  return {
+    title: item.titleEn,
+    summary: item.summaryEn,
+    prompt,
+    author: englishAuthor(item),
+    model: englishModel(item.model),
+    sourceLabel: englishSourceLabel(item),
+    resolution: englishOutputValue(item.resolution),
+    aspectRatio: englishOutputValue(item.aspectRatio),
+    tags: [...new Set([item.category, ...item.styles, ...item.scenes])],
+  }
+}
+
+function alternateHeadLinks(paths) {
+  return `  <link rel="alternate" hreflang="zh-CN" href="${absolute(paths['zh-CN'])}" />
+  <link rel="alternate" hreflang="en" href="${absolute(paths.en)}" />
+  <link rel="alternate" hreflang="x-default" href="${absolute(paths['zh-CN'])}" />`
+}
+
+function alternateSitemapLinks(paths) {
+  return `    <xhtml:link rel="alternate" hreflang="zh-CN" href="${escapeHtml(absolute(paths['zh-CN']))}" />
+    <xhtml:link rel="alternate" hreflang="en" href="${escapeHtml(absolute(paths.en))}" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="${escapeHtml(absolute(paths['zh-CN']))}" />`
+}
+
+function appStructuredData(page, locale) {
+  const canonical = absolute(page.paths[locale])
+  const copy = page.copy[locale]
+  return {
+    '@context': 'https://schema.org',
+    '@type': page.schemaType,
+    name: copy.title,
+    description: copy.description,
+    url: canonical,
+    inLanguage: locale,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'H3 Field Notes',
+      url: `${baseUrl}/`,
+    },
+    about: ['MiniMax H3', 'Hailuo 3.0', 'AI video generation'],
+  }
+}
+
+function renderAppShell(page, locale, assetTags) {
+  const copy = page.copy[locale]
+  const canonical = absolute(page.paths[locale])
+  const alternateOgLocale = localeCode(otherLocale(locale))
+  return `<!doctype html>
+<html lang="${locale}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0b09" />
+    <meta name="description" content="${escapeHtml(copy.description)}" />
+    <meta name="keywords" content="${escapeHtml(copy.keywords)}" />
+    <meta name="robots" content="index,follow,max-image-preview:large,max-video-preview:-1" />
+    <link rel="canonical" href="${canonical}" />
+${alternateHeadLinks(page.paths)}
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="H3 Field Notes" />
+    <meta property="og:locale" content="${localeCode(locale)}" />
+    <meta property="og:locale:alternate" content="${alternateOgLocale}" />
+    <meta property="og:title" content="${escapeHtml(copy.title)}" />
+    <meta property="og:description" content="${escapeHtml(copy.description)}" />
+    <meta property="og:url" content="${canonical}" />
+    <meta property="og:image" content="${baseUrl}/og-image.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="${escapeHtml(copy.title)}" />
+    <meta name="twitter:description" content="${escapeHtml(copy.description)}" />
+    <meta name="twitter:image" content="${baseUrl}/og-image.jpg" />
+    <script type="application/ld+json">${jsonForHtml(appStructuredData(page, locale))}</script>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230a0b09'/%3E%3Cpath d='M14 16h8v12h20V16h8v32h-8V36H22v12h-8z' fill='%23d8ff3e'/%3E%3C/svg%3E" />
+    <title>${escapeHtml(copy.title)}</title>
+${assetTags.map((tag) => `    ${tag}`).join('\n')}
+  </head>
+  <body>
+    <div id="root"></div>
+    <noscript>${escapeHtml(locale === 'en' ? 'JavaScript is required to browse this video library.' : '浏览此视频案例库需要启用 JavaScript。')}</noscript>
+  </body>
+</html>
+`
+}
+
+const casePageStyle = `body{margin:0;background:#0a0b09;color:#f5f5ed;font:16px/1.65 Inter,system-ui,sans-serif}main{max-width:980px;margin:auto;padding:36px 20px 80px}a{color:#d8ff3e}.case-nav{display:flex;justify-content:space-between;gap:20px;margin-bottom:1rem}.eyebrow{color:#d8ff3e;letter-spacing:.12em;text-transform:uppercase}h1{font-size:clamp(2rem,7vw,5rem);line-height:1;margin:.25em 0}.summary{font-size:1.2rem;color:#c7c9bd}.prompt-notice{color:#929689;font-size:.88rem}video{display:block;width:100%;max-height:70vh;background:#000;border:1px solid #34362e}.x-embed{min-height:560px;margin:28px 0;padding:22px;display:flex;gap:12px;flex-direction:column;align-items:center;justify-content:center;background-color:#050605;background-image:linear-gradient(rgba(216,255,62,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(216,255,62,.035) 1px,transparent 1px);background-size:32px 32px;border:1px solid #34362e}.embed-label{width:100%;max-width:550px;display:flex;justify-content:space-between;color:#d8ff3e;font:11px ui-monospace,monospace;letter-spacing:.08em;text-transform:uppercase}.embed-label small{color:#929689}.embed-stage{position:relative;width:100%;max-width:550px;min-height:460px;display:grid;place-items:center;overflow:hidden;background:#0a0c09;border:1px solid #30342c}.embed-stage:after{content:'';position:absolute;z-index:2;top:0;left:0;right:0;height:1px;background:#d8ff3e;box-shadow:0 0 18px rgba(216,255,62,.85);animation:scan 2.4s ease-in-out infinite}.embed-poster,.embed-scrim{position:absolute;inset:0;width:100%;height:100%;transition:opacity .3s,visibility .3s}.embed-poster{object-fit:cover;filter:saturate(.82) contrast(1.08)}.embed-scrim{z-index:1;background:linear-gradient(180deg,rgba(5,6,5,.18),rgba(5,6,5,.8)),repeating-linear-gradient(0deg,transparent 0 3px,rgba(216,255,62,.045) 3px 4px)}.embed-target{position:relative;z-index:3;width:100%;min-height:460px;display:grid;place-items:center;opacity:0}.twitter-tweet{width:100%;min-height:460px;display:grid;place-items:center;margin:0 auto!important}.embed-status{position:absolute;z-index:4;inset:0;padding:38px;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;gap:18px;text-shadow:0 2px 18px #000}.embed-loader{width:48px;height:48px;border:1px solid rgba(216,255,62,.4);background:rgba(7,8,6,.55)}.embed-loader:after{content:'';display:block;width:20px;height:20px;margin:13px;border:3px solid #d8ff3e;border-right-color:transparent;border-radius:50%;animation:spin 1.1s linear infinite}.embed-copy{max-width:430px;display:flex;flex-direction:column;gap:5px}.embed-copy small{color:#d8ff3e;font:9px ui-monospace,monospace;letter-spacing:.16em}.embed-copy strong{font-size:25px;line-height:1.2}.embed-copy em{color:#d0d2c8;font:normal 10px/1.65 ui-monospace,monospace}.embed-retry{display:none;padding:9px 12px;color:#090a08;background:#d8ff3e;border:0;font:10px ui-monospace,monospace;cursor:pointer}.x-embed[data-state=slow] .embed-stage:after{background:#ffd166;box-shadow:0 0 18px rgba(255,209,102,.78);animation-duration:3.4s}.x-embed[data-state=slow] .embed-copy small{color:#ffd166}.x-embed[data-state=error] .embed-stage:after,.x-embed[data-state=error] .embed-loader{display:none}.x-embed[data-state=error] .embed-copy small{color:#ff806f}.x-embed[data-state=error] .embed-retry{display:block}.x-embed[data-state=ready] .embed-poster,.x-embed[data-state=ready] .embed-scrim,.x-embed[data-state=ready] .embed-status,.x-embed[data-state=ready] .embed-stage:after{opacity:0;visibility:hidden}.x-embed[data-state=ready] .embed-target{opacity:1}.embed-fallback{margin:0;font:11px ui-monospace,monospace}dl{display:grid;grid-template-columns:max-content 1fr;gap:.5rem 1.25rem;margin:2rem 0}dt{color:#929689}dd{margin:0}pre{white-space:pre-wrap;background:#151712;border:1px solid #34362e;padding:20px;overflow:auto}@keyframes spin{to{transform:rotate(360deg)}}@keyframes scan{0%,100%{transform:translateY(0)}50%{transform:translateY(459px)}}@media(max-width:620px){.x-embed{padding:12px}.embed-stage,.embed-target,.twitter-tweet{min-height:410px}.embed-status{padding:24px}dl{grid-template-columns:1fr;gap:.1rem}dd{margin-bottom:.75rem}}@media(prefers-reduced-motion:reduce){*{animation-duration:.01ms!important;animation-iteration-count:1!important}}`
+
+function renderXEmbed(item, copy, labels, poster) {
+  const stateText = {
+    slow: [labels.slowLabel, labels.slowTitle, labels.slowDetail],
+    error: [labels.failedLabel, labels.failedTitle, labels.failedDetail],
+  }
+  const markup = `<section class="x-embed" data-state="loading" aria-busy="true" aria-label="${escapeHtml(`${copy.title} · ${labels.playerLabel}`)}"><div class="embed-label"><span>${escapeHtml(labels.playerLabel)}</span><small>${escapeHtml(labels.playerProvider)}</small></div><div class="embed-stage"><img class="embed-poster" src="${escapeHtml(poster)}" alt="${escapeHtml(`${copy.title} · ${labels.coverAlt}`)}"><span class="embed-scrim" aria-hidden="true"></span><div class="embed-target"><blockquote class="twitter-tweet" data-theme="dark" data-dnt="true" data-conversation="none"><a href="${escapeHtml(item.sourceUrl)}">${escapeHtml(labels.embedLink)}</a></blockquote></div><div class="embed-status" role="status" aria-live="polite"><span class="embed-loader" aria-hidden="true"></span><span class="embed-copy"><small>${escapeHtml(labels.connectingLabel)}</small><strong>${escapeHtml(labels.connectingTitle)}</strong><em>${escapeHtml(labels.connectingDetail)}</em></span><button class="embed-retry" type="button">${escapeHtml(labels.retry)}</button></div></div><p class="embed-fallback"><a href="${escapeHtml(item.sourceUrl)}" rel="nofollow noopener">${escapeHtml(labels.fallback)} ↗</a></p></section>`
+  const script = `<script>(()=>{const root=document.querySelector('.x-embed');const copy=root.querySelector('.embed-copy');const status=root.querySelector('.embed-status');const retry=root.querySelector('.embed-retry');const states=${jsonForHtml(stateText)};let done=false;const setState=(state)=>{if(done)return;const [label,title,detail]=states[state];root.dataset.state=state;root.setAttribute('aria-busy',String(state!=='error'));status.setAttribute('role',state==='error'?'alert':'status');status.setAttribute('aria-live',state==='error'?'assertive':'polite');copy.querySelector('small').textContent=label;copy.querySelector('strong').textContent=title;copy.querySelector('em').textContent=detail};const ready=()=>{if(!root.querySelector('iframe'))return false;done=true;clearTimeout(slowTimer);clearTimeout(failTimer);root.dataset.state='ready';root.setAttribute('aria-busy','false');observer.disconnect();return true};const observer=new MutationObserver(ready);observer.observe(root,{childList:true,subtree:true});const slowTimer=setTimeout(()=>setState('slow'),6000);const failTimer=setTimeout(()=>setState('error'),20000);retry.addEventListener('click',()=>location.reload());ready()})()</script>`
+  return { markup, script }
+}
+
+function renderCasePage(item, locale) {
+  const copy = localizedCase(item, locale)
+  const labels = ui[locale]
+  const canonical = absolute(casePath(locale, item.id))
+  const paths = {
+    'zh-CN': casePath('zh-CN', item.id),
+    en: casePath('en', item.id),
+  }
+  const alternate = absolute(paths[otherLocale(locale)])
   const poster = absolute(item.posterUrl)
   const hasHostedVideo = Boolean(item.mediaUrl)
   const keywords = [
-    'MiniMax H3', 'Hailuo 3.0', 'AI video generation', 'video prompts',
-    item.mode, item.category, ...item.tags, ...item.styles, ...item.scenes,
+    'MiniMax H3', 'Hailuo 3.0', 'AI video generation',
+    item.mode, item.category, ...copy.tags,
   ].join(', ')
   const structuredData = hasHostedVideo
     ? {
         '@context': 'https://schema.org',
         '@type': 'VideoObject',
-        name: `${item.title} — ${item.titleEn}`,
-        description: item.summary,
+        name: copy.title,
+        description: copy.summary,
         thumbnailUrl: [poster],
         uploadDate: item.publishedAt,
         duration: isoDuration(item.duration),
         contentUrl: item.mediaUrl,
         embedUrl: canonical,
-        creator: { '@type': 'Organization', name: item.author },
+        creator: { '@type': 'Organization', name: copy.author },
+        inLanguage: locale,
         isFamilyFriendly: true,
         keywords,
       }
     : {
         '@context': 'https://schema.org',
         '@type': 'Article',
-        headline: `${item.title} — MiniMax H3 社区案例`,
-        description: item.summary,
+        headline: copy.title,
+        description: copy.summary,
         image: [poster],
         datePublished: item.publishedAt,
-        author: { '@type': 'Person', name: item.author },
+        author: { '@type': 'Person', name: copy.author },
         mainEntityOfPage: canonical,
         citation: item.sourceUrl,
+        inLanguage: locale,
         keywords,
       }
   const videoMeta = hasHostedVideo
     ? `  <meta property="og:video" content="${escapeHtml(item.mediaUrl)}" />
   <meta property="og:video:type" content="video/mp4" />`
     : ''
+  const embedded = hasHostedVideo ? null : renderXEmbed(item, copy, labels, poster)
   const mediaMarkup = hasHostedVideo
-    ? `<video controls playsinline preload="metadata" poster="${poster}" src="${escapeHtml(item.mediaUrl)}"></video>`
-    : `<section class="x-embed" data-state="loading" aria-busy="true" aria-label="${escapeHtml(item.title)} X 原帖播放器"><div class="embed-label"><span>X 原帖播放器</span><small>媒体由 X 提供</small></div><div class="embed-stage"><img class="embed-poster" src="${poster}" alt="${escapeHtml(item.title)} 视频封面"><span class="embed-scrim" aria-hidden="true"></span><div class="embed-target"><blockquote class="twitter-tweet" data-theme="dark" data-dnt="true" data-conversation="none"><a href="${escapeHtml(item.sourceUrl)}">载入 ${escapeHtml(item.title)} 的 X 原帖视频</a></blockquote></div><div class="embed-status" role="status" aria-live="polite"><span class="embed-loader" aria-hidden="true"></span><span class="embed-copy"><small>CONNECTING</small><strong>正在连接 X 播放器</strong><em>视频封面已就绪，播放器通常会在 2–8 秒内出现。</em></span><button class="embed-retry" type="button">重新加载</button></div></div><p class="embed-fallback"><a href="${escapeHtml(item.sourceUrl)}" rel="nofollow noopener">播放器受限时在 X 打开原帖 ↗</a></p></section>`
-  const embedScript = hasHostedVideo ? '' : `<script>(()=>{const root=document.querySelector('.x-embed');const copy=root.querySelector('.embed-copy');const retry=root.querySelector('.embed-retry');let done=false;const setState=(state,label,title,detail)=>{if(done)return;root.dataset.state=state;root.setAttribute('aria-busy',String(state!=='error'));copy.querySelector('small').textContent=label;copy.querySelector('strong').textContent=title;copy.querySelector('em').textContent=detail};const ready=()=>{if(!root.querySelector('iframe'))return false;done=true;clearTimeout(slowTimer);clearTimeout(failTimer);root.dataset.state='ready';root.setAttribute('aria-busy','false');observer.disconnect();return true};const observer=new MutationObserver(ready);observer.observe(root,{childList:true,subtree:true});const slowTimer=setTimeout(()=>setState('slow','SLOW RESPONSE','X 响应较慢，仍在加载','网络或隐私设置可能延迟播放器；你可以继续等待。'),6000);const failTimer=setTimeout(()=>setState('error','LOAD FAILED','播放器加载失败','请重新加载，或直接在 X 打开原帖。'),20000);retry.addEventListener('click',()=>location.reload());ready()})()</script>`
-  const html = `<!doctype html>
-<html lang="zh-CN">
+    ? `<video controls playsinline preload="metadata" poster="${escapeHtml(poster)}" src="${escapeHtml(item.mediaUrl)}"></video>`
+    : embedded.markup
+  const provenance = provenanceLabels[locale][item.promptProvenance] ?? item.promptProvenance
+  const localeTitleSuffix = locale === 'en'
+    ? 'MiniMax H3 / Hailuo 3.0 video prompt'
+    : 'MiniMax H3 / Hailuo 3.0 视频提示词'
+
+  return `<!doctype html>
+<html lang="${locale}">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${escapeHtml(item.title)} — MiniMax H3 / Hailuo 3.0 视频提示词</title>
-  <meta name="description" content="${escapeHtml(item.summary)} MiniMax H3 ${escapeHtml(item.mode)} AI 视频案例、提示词记录与原始来源。" />
+  <title>${escapeHtml(copy.title)} — ${localeTitleSuffix}</title>
+  <meta name="description" content="${escapeHtml(copy.summary)}" />
+  <meta name="keywords" content="${escapeHtml(keywords)}" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-video-preview:-1" />
   <link rel="canonical" href="${canonical}" />
+${alternateHeadLinks(paths)}
   <meta property="og:type" content="${hasHostedVideo ? 'video.other' : 'article'}" />
   <meta property="og:site_name" content="H3 Field Notes" />
-  <meta property="og:title" content="${escapeHtml(item.title)} — MiniMax H3 视频案例" />
-  <meta property="og:description" content="${escapeHtml(item.summary)}" />
+  <meta property="og:locale" content="${localeCode(locale)}" />
+  <meta property="og:locale:alternate" content="${localeCode(otherLocale(locale))}" />
+  <meta property="og:title" content="${escapeHtml(`${copy.title} — MiniMax H3`)}" />
+  <meta property="og:description" content="${escapeHtml(copy.summary)}" />
   <meta property="og:url" content="${canonical}" />
-  <meta property="og:image" content="${poster}" />
+  <meta property="og:image" content="${escapeHtml(poster)}" />
 ${videoMeta}
-  <meta name="twitter:card" content="${hasHostedVideo ? 'player' : 'summary_large_image'}" />
-  <meta name="twitter:title" content="${escapeHtml(item.title)} — MiniMax H3" />
-  <meta name="twitter:description" content="${escapeHtml(item.summary)}" />
-  <meta name="twitter:image" content="${poster}" />
-  <script type="application/ld+json">${JSON.stringify(structuredData).replaceAll('<', '\\u003c')}</script>
-  <style>body{margin:0;background:#0a0b09;color:#f5f5ed;font:16px/1.65 Inter,system-ui,sans-serif}main{max-width:980px;margin:auto;padding:36px 20px 80px}a{color:#d8ff3e}.eyebrow{color:#d8ff3e;letter-spacing:.12em;text-transform:uppercase}h1{font-size:clamp(2rem,7vw,5rem);line-height:1;margin:.25em 0}.summary{font-size:1.2rem;color:#c7c9bd}video{display:block;width:100%;max-height:70vh;background:#000;border:1px solid #34362e}.x-embed{min-height:560px;margin:28px 0;padding:22px;display:flex;gap:12px;flex-direction:column;align-items:center;justify-content:center;background-color:#050605;background-image:linear-gradient(rgba(216,255,62,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(216,255,62,.035) 1px,transparent 1px);background-size:32px 32px;border:1px solid #34362e}.embed-label{width:100%;max-width:550px;display:flex;justify-content:space-between;color:#d8ff3e;font:11px ui-monospace,monospace;letter-spacing:.08em;text-transform:uppercase}.embed-label small{color:#929689}.embed-stage{position:relative;width:100%;max-width:550px;min-height:460px;display:grid;place-items:center;overflow:hidden;background:#0a0c09;border:1px solid #30342c}.embed-stage:after{content:'';position:absolute;z-index:2;top:0;left:0;right:0;height:1px;background:#d8ff3e;box-shadow:0 0 18px rgba(216,255,62,.85);animation:scan 2.4s ease-in-out infinite}.embed-poster,.embed-scrim{position:absolute;inset:0;width:100%;height:100%;transition:opacity .3s,visibility .3s}.embed-poster{object-fit:cover;filter:saturate(.82) contrast(1.08)}.embed-scrim{z-index:1;background:linear-gradient(180deg,rgba(5,6,5,.18),rgba(5,6,5,.8)),repeating-linear-gradient(0deg,transparent 0 3px,rgba(216,255,62,.045) 3px 4px)}.embed-target{position:relative;z-index:3;width:100%;min-height:460px;display:grid;place-items:center;opacity:0}.twitter-tweet{width:100%;min-height:460px;display:grid;place-items:center;margin:0 auto!important}.embed-status{position:absolute;z-index:4;inset:0;padding:38px;display:flex;flex-direction:column;justify-content:flex-end;align-items:flex-start;gap:18px;text-shadow:0 2px 18px #000}.embed-loader{width:48px;height:48px;border:1px solid rgba(216,255,62,.4);background:rgba(7,8,6,.55)}.embed-loader:after{content:'';display:block;width:20px;height:20px;margin:13px;border:3px solid #d8ff3e;border-right-color:transparent;border-radius:50%;animation:spin 1.1s linear infinite}.embed-copy{max-width:430px;display:flex;flex-direction:column;gap:5px}.embed-copy small{color:#d8ff3e;font:9px ui-monospace,monospace;letter-spacing:.16em}.embed-copy strong{font-size:25px;line-height:1.2}.embed-copy em{color:#d0d2c8;font:normal 10px/1.65 ui-monospace,monospace}.embed-retry{display:none;padding:9px 12px;color:#090a08;background:#d8ff3e;border:0;font:10px ui-monospace,monospace;cursor:pointer}.x-embed[data-state=slow] .embed-stage:after{background:#ffd166;box-shadow:0 0 18px rgba(255,209,102,.78);animation-duration:3.4s}.x-embed[data-state=slow] .embed-copy small{color:#ffd166}.x-embed[data-state=error] .embed-stage:after{display:none}.x-embed[data-state=error] .embed-copy small{color:#ff806f}.x-embed[data-state=error] .embed-retry{display:block}.x-embed[data-state=ready] .embed-poster,.x-embed[data-state=ready] .embed-scrim,.x-embed[data-state=ready] .embed-status,.x-embed[data-state=ready] .embed-stage:after{opacity:0;visibility:hidden}.x-embed[data-state=ready] .embed-target{opacity:1}.embed-fallback{margin:0;font:11px ui-monospace,monospace}dl{display:grid;grid-template-columns:max-content 1fr;gap:.5rem 1.25rem;margin:2rem 0}dt{color:#929689}dd{margin:0}pre{white-space:pre-wrap;background:#151712;border:1px solid #34362e;padding:20px;overflow:auto}.back{display:inline-block;margin-bottom:1rem}@keyframes spin{to{transform:rotate(360deg)}}@keyframes scan{0%,100%{transform:translateY(0)}50%{transform:translateY(459px)}}@media(max-width:620px){.x-embed{padding:12px}.embed-stage,.embed-target,.twitter-tweet{min-height:410px}.embed-status{padding:24px}}@media(prefers-reduced-motion:reduce){*{animation-duration:.01ms!important;animation-iteration-count:1!important}}</style>
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${escapeHtml(`${copy.title} — MiniMax H3`)}" />
+  <meta name="twitter:description" content="${escapeHtml(copy.summary)}" />
+  <meta name="twitter:image" content="${escapeHtml(poster)}" />
+  <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
+  <style>${casePageStyle}</style>
   ${hasHostedVideo ? '' : '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>'}
 </head>
 <body><main>
-  <a class="back" href="${baseUrl}/">← H3 Field Notes 案例库</a>
+  <nav class="case-nav" aria-label="${escapeHtml(locale === 'en' ? 'Case navigation' : '案例导航')}"><a href="${absolute(locale === 'en' ? '/en/' : '/')}">← ${escapeHtml(labels.back)}</a><a href="${alternate}" hreflang="${otherLocale(locale)}">${escapeHtml(labels.language)}</a></nav>
   <p class="eyebrow">MiniMax H3 / Hailuo 3.0 · ${escapeHtml(item.mode)}</p>
-  <h1>${escapeHtml(item.title)}</h1>
-  <p>${escapeHtml(item.titleEn)}</p>
-  <p class="summary">${escapeHtml(item.summary)}</p>
+  <h1>${escapeHtml(copy.title)}</h1>
+  <p class="summary">${escapeHtml(copy.summary)}</p>
   ${mediaMarkup}
-  <dl><dt>生成模式</dt><dd>${escapeHtml(item.mode)}</dd><dt>模型</dt><dd>${escapeHtml(item.model)}</dd><dt>输出</dt><dd>${item.duration}s · ${escapeHtml(item.resolution)} · ${escapeHtml(item.aspectRatio)}</dd><dt>标签</dt><dd>${escapeHtml(item.tags.join(' · '))}</dd><dt>提示词来源</dt><dd>${escapeHtml(item.promptProvenance)}</dd></dl>
-  <h2>MiniMax H3 提示词记录</h2>
-  <pre>${escapeHtml(item.prompt)}</pre>
-  <p><a href="${escapeHtml(item.sourceUrl)}" rel="nofollow noopener">查看原始来源 · ${escapeHtml(item.sourceLabel)}</a></p>
-</main>${embedScript}</body></html>`
-  const pageDir = resolve(dist, 'cases', item.id)
-  await mkdir(pageDir, { recursive: true })
-  await writeFile(resolve(pageDir, 'index.html'), html)
+  <dl><dt>${escapeHtml(labels.mode)}</dt><dd>${escapeHtml(item.mode)}</dd><dt>${escapeHtml(labels.model)}</dt><dd>${escapeHtml(copy.model)}</dd><dt>${escapeHtml(labels.output)}</dt><dd>${item.duration}s · ${escapeHtml(copy.resolution)} · ${escapeHtml(copy.aspectRatio)}</dd><dt>${escapeHtml(labels.tags)}</dt><dd>${escapeHtml(copy.tags.join(' · '))}</dd><dt>${escapeHtml(labels.provenance)}</dt><dd>${escapeHtml(provenance)}</dd></dl>
+  <h2>${escapeHtml(labels.promptHeading)}</h2>
+  <p class="prompt-notice">${escapeHtml(labels.promptNotice)}</p>
+  <pre>${escapeHtml(copy.prompt)}</pre>
+  <p><a href="${escapeHtml(item.sourceUrl)}" rel="nofollow noopener">${escapeHtml(labels.source)} · ${escapeHtml(copy.sourceLabel)}</a></p>
+</main>${embedded?.script ?? ''}</body></html>`
 }
 
-const sitemapEntries = cases.map((item) => item.mediaUrl
-  ? `  <url>
-    <loc>${baseUrl}/cases/${encodeURIComponent(item.id)}/</loc>
+function extractAssetTags(builtIndex) {
+  const links = builtIndex.match(/<link\b[^>]*\bhref="\/assets\/[^"]+"[^>]*>/g) ?? []
+  const scripts = builtIndex.match(/<script\b[^>]*\bsrc="\/assets\/[^"]+"[^>]*><\/script>/g) ?? []
+  if (scripts.length === 0) {
+    throw new Error('Could not find the Vite application entry in dist/index.html. Run vite build before the SEO generator.')
+  }
+  return [...new Set([...links, ...scripts])]
+}
+
+const builtIndex = await readFile(resolve(dist, 'index.html'), 'utf8')
+const assetTags = extractAssetTags(builtIndex)
+
+for (const page of pageDefinitions) {
+  for (const locale of locales) {
+    const relativePath = page.paths[locale].replace(/^\//, '')
+    const pageDir = resolve(dist, relativePath)
+    const html = renderAppShell(page, locale, assetTags)
+    assertLanguageIsolation(html, locale, page.paths[locale])
+    await mkdir(pageDir, { recursive: true })
+    await writeFile(resolve(pageDir, 'index.html'), html)
+  }
+}
+
+for (const item of cases) {
+  for (const locale of locales) {
+    const relativePath = casePath(locale, item.id).replace(/^\//, '')
+    const pageDir = resolve(dist, relativePath)
+    const html = renderCasePage(item, locale)
+    assertLanguageIsolation(html, locale, casePath(locale, item.id))
+    await mkdir(pageDir, { recursive: true })
+    await writeFile(resolve(pageDir, 'index.html'), html)
+  }
+}
+
+function sitemapPageEntry(page, locale) {
+  return `  <url>
+    <loc>${escapeHtml(absolute(page.paths[locale]))}</loc>
+${alternateSitemapLinks(page.paths)}
+  </url>`
+}
+
+function sitemapCaseEntry(item, locale) {
+  const copy = localizedCase(item, locale)
+  const paths = {
+    'zh-CN': casePath('zh-CN', item.id),
+    en: casePath('en', item.id),
+  }
+  const video = item.mediaUrl
+    ? `
     <video:video>
-      <video:thumbnail_loc>${absolute(item.posterUrl)}</video:thumbnail_loc>
-      <video:title>${escapeHtml(item.title)} — MiniMax H3</video:title>
-      <video:description>${escapeHtml(item.summary)}</video:description>
+      <video:thumbnail_loc>${escapeHtml(absolute(item.posterUrl))}</video:thumbnail_loc>
+      <video:title>${escapeHtml(`${copy.title} — MiniMax H3`)}</video:title>
+      <video:description>${escapeHtml(copy.summary)}</video:description>
       <video:content_loc>${escapeHtml(item.mediaUrl)}</video:content_loc>
       <video:duration>${item.duration}</video:duration>
-      <video:publication_date>${item.publishedAt}</video:publication_date>
+      <video:publication_date>${escapeHtml(item.publishedAt)}</video:publication_date>
       <video:family_friendly>yes</video:family_friendly>
-    </video:video>
+    </video:video>`
+    : ''
+  return `  <url>
+    <loc>${escapeHtml(absolute(paths[locale]))}</loc>
+${alternateSitemapLinks(paths)}${video}
   </url>`
-  : `  <url><loc>${baseUrl}/cases/${encodeURIComponent(item.id)}/</loc></url>`).join('\n')
+}
+
+const sitemapEntries = [
+  ...pageDefinitions.flatMap((page) => locales.map((locale) => sitemapPageEntry(page, locale))),
+  ...cases.flatMap((item) => locales.map((locale) => sitemapCaseEntry(item, locale))),
+].join('\n')
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-  <url><loc>${baseUrl}/</loc></url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 ${sitemapEntries}
 </urlset>\n`
 await writeFile(resolve(dist, 'sitemap.xml'), sitemap)
 await writeFile(resolve(dist, 'robots.txt'), `User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml\n`)
-console.log(`Generated ${cases.length} case pages and a video sitemap for ${baseUrl}.`)
+console.log(`Generated ${pageDefinitions.length * locales.length} app routes, ${cases.length * locales.length} localized case pages, and a bilingual sitemap for ${baseUrl}.`)

--- a/scripts/validate-data.mjs
+++ b/scripts/validate-data.mjs
@@ -11,8 +11,14 @@ const errors = []
 
 for (const [index, item] of cases.entries()) {
   const at = `cases[${index}]`
-  for (const key of ['id', 'title', 'model', 'mode', 'prompt', 'sourceUrl', 'author', 'category', 'posterUrl']) {
+  for (const key of ['id', 'title', 'titleEn', 'summary', 'summaryEn', 'model', 'mode', 'prompt', 'sourceUrl', 'author', 'category', 'posterUrl']) {
     if (!item[key]) errors.push(`${at}.${key} is required`)
+  }
+  if (/[\u3400-\u9fff]/u.test(item.titleEn || '')) errors.push(`${at}.titleEn must not contain CJK text`)
+  if (/[\u3400-\u9fff]/u.test(item.summaryEn || '')) errors.push(`${at}.summaryEn must not contain CJK text`)
+  if (/[\u3400-\u9fff]/u.test(item.prompt || '')) {
+    if (!item.promptEn) errors.push(`${at}.promptEn is required when prompt contains CJK text`)
+    if (/[\u3400-\u9fff]/u.test(item.promptEn || '')) errors.push(`${at}.promptEn must not contain CJK text`)
   }
   if (ids.has(item.id)) errors.push(`${at}.id is duplicated: ${item.id}`)
   ids.add(item.id)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,24 +1,56 @@
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 
+function renderAt(pathname: string) {
+  window.history.replaceState({}, '', pathname)
+  return render(<App />)
+}
+
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
+  window.history.replaceState({}, '', '/')
+  document.body.classList.remove('intro-open', 'modal-open')
   delete window.twttr
 })
 
-describe('case catalog', () => {
+describe('case-first routes', () => {
+  it('renders the case browser underneath a two-second intro and then removes the intro', () => {
+    vi.useFakeTimers()
+    renderAt('/')
+
+    expect(screen.getByLabelText('MiniMax H3 社区视频实验档案')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '先看效果，再拆工作流。' })).toBeInTheDocument()
+    expect(screen.getByText('舰桥上的跃迁余震')).toBeInTheDocument()
+
+    act(() => vi.advanceTimersByTime(1_600))
+    expect(screen.getByLabelText('MiniMax H3 社区视频实验档案')).toHaveClass('is-leaving')
+    act(() => vi.advanceTimersByTime(500))
+    expect(screen.queryByLabelText('MiniMax H3 社区视频实验档案')).not.toBeInTheDocument()
+  })
+
+  it('keeps the home page focused on cases and removes template and collection-method sections', () => {
+    renderAt('/')
+    expect(screen.getByRole('link', { name: '案例' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: '工具链' })).toHaveAttribute('href', '/toolkit/')
+    expect(screen.getByRole('link', { name: '常见问题' })).toHaveAttribute('href', '/faq/')
+    expect(screen.queryByText('从单个案例，提炼可复用镜头协议。')).not.toBeInTheDocument()
+    expect(screen.queryByText('收录方式')).not.toBeInTheDocument()
+    expect(screen.queryByText('从提示词，一路接到成片。')).not.toBeInTheDocument()
+  })
+
   it('filters cases by generation mode', () => {
-    render(<App />)
+    renderAt('/')
     fireEvent.click(screen.getByRole('button', { name: /全模态参考/ }))
     expect(screen.getByText('粉色西装与黑色羔羊')).toBeInTheDocument()
     expect(screen.queryByText('舰桥上的跃迁余震')).not.toBeInTheDocument()
   })
 
-  it('searches across case tags', () => {
-    render(<App />)
-    fireEvent.change(screen.getByPlaceholderText('搜索提示词、场景、标签…'), {
+  it('searches across localized case metadata', () => {
+    renderAt('/')
+    fireEvent.change(screen.getByPlaceholderText('搜索案例、场景、工作流…'), {
       target: { value: '焦点转移' },
     })
     expect(screen.getByText('拉面与家庭晚餐')).toBeInTheDocument()
@@ -28,8 +60,8 @@ describe('case catalog', () => {
   it('loads the official in-site X player and keeps a source fallback', async () => {
     const createTweet = vi.fn().mockResolvedValue(document.createElement('iframe'))
     window.twttr = { widgets: { createTweet } }
-    render(<App />)
-    fireEvent.change(screen.getByPlaceholderText('搜索提示词、场景、标签…'), {
+    renderAt('/')
+    fireEvent.change(screen.getByPlaceholderText('搜索案例、场景、工作流…'), {
       target: { value: '时间冻结' },
     })
     fireEvent.click(screen.getByRole('button', { name: '查看 餐厅时间冻结与逆向复原 详情' }))
@@ -40,45 +72,65 @@ describe('case catalog', () => {
     await waitFor(() => expect(createTweet).toHaveBeenCalledWith(
       '2085297962977227011',
       expect.any(HTMLElement),
-      expect.objectContaining({ dnt: true, theme: 'dark' }),
+      expect.objectContaining({ dnt: true, theme: 'dark', lang: 'zh-cn' }),
     ))
   })
 
-  it('keeps uncertain community modes explicitly labeled', () => {
-    render(<App />)
-    fireEvent.click(screen.getByRole('button', { name: '模式待确认' }))
-    expect(screen.getByText('分层构图音乐视频')).toBeInTheDocument()
-    expect(screen.getByText('跨平台 UGC 种草短片')).toBeInTheDocument()
-  })
-
-  it('includes the newly approved multimodal community cases', () => {
-    render(<App />)
-    fireEvent.change(screen.getByPlaceholderText('搜索提示词、场景、标签…'), {
-      target: { value: '九图参考' },
-    })
-    expect(screen.getByText('九图参考 AI 电影预告')).toBeInTheDocument()
-    expect(screen.queryByText('舰桥上的跃迁余震')).not.toBeInTheDocument()
-  })
-
-  it('publishes the four-part H3 toolkit instead of a standalone weights link', () => {
-    render(<App />)
-    expect(screen.getByRole('link', { name: '工具链' })).toHaveAttribute('href', '#toolkit')
-    expect(screen.getByRole('link', { name: 'MiniMax-AI / MiniMax-H3：打开官方仓库' })).toHaveAttribute(
+  it('publishes Toolkit and FAQ as standalone pages', () => {
+    const toolkit = renderAt('/toolkit/')
+    expect(screen.getByRole('heading', { name: '从提示词，一路接到成片。' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'MiniMax-AI / MiniMax-H3: 打开官方仓库' })).toHaveAttribute(
       'href',
       'https://github.com/MiniMax-AI/MiniMax-H3',
     )
-    expect(screen.getByRole('link', { name: 'MiniMax-H3 Turbo LoRA：打开 Hugging Face' })).toHaveAttribute(
+    expect(screen.queryByRole('heading', { name: '先看效果，再拆工作流。' })).not.toBeInTheDocument()
+    toolkit.unmount()
+
+    renderAt('/faq/')
+    expect(screen.getByRole('heading', { name: '先把边界讲清楚。' })).toBeInTheDocument()
+    expect(screen.getByText('MiniMax H3 和 Hailuo 3.0 是什么关系？')).toBeInTheDocument()
+    expect(screen.queryByText('打开官方仓库')).not.toBeInTheDocument()
+  })
+})
+
+describe('language isolation', () => {
+  it('renders the English home without duplicated Chinese case or interface copy', () => {
+    renderAt('/en/')
+    expect(document.documentElement).toHaveAttribute('lang', 'en')
+    expect(screen.getByRole('heading', { name: 'See the result. Trace the workflow.' })).toBeInTheDocument()
+    expect(screen.getByText('After the Fleet Jumps')).toBeInTheDocument()
+    expect(screen.queryByText('舰桥上的跃迁余震')).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search cases, scenes, workflows…')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Toolkit' })).toHaveAttribute('href', '/en/toolkit/')
+    expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/')
+    expect(document.body.textContent).not.toMatch(/[\u3400-\u9fff]/u)
+  })
+
+  it('keeps the language switch on the equivalent standalone route', () => {
+    renderAt('/en/toolkit/')
+    expect(screen.getByRole('heading', { name: 'From prompt to finished cut.' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/toolkit/')
+    expect(screen.queryByText('打开官方仓库')).not.toBeInTheDocument()
+  })
+
+  it('localizes the English X player and case dialog', async () => {
+    const createTweet = vi.fn().mockResolvedValue(document.createElement('iframe'))
+    window.twttr = { widgets: { createTweet } }
+    renderAt('/en/')
+    fireEvent.change(screen.getByPlaceholderText('Search cases, scenes, workflows…'), {
+      target: { value: 'rewinds' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'View details for The Diner That Rewinds' }))
+    expect(screen.getByText('Connecting to the X player')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open the original post on X/ })).toHaveAttribute(
       'href',
-      'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
+      'https://x.com/icreat_ai/status/2085297962977227011',
     )
-    expect(screen.getByRole('link', { name: 'ComfyUI H3 Motion Context：打开续接节点' })).toHaveAttribute(
-      'href',
-      'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
-    )
-    expect(screen.getByRole('link', { name: 'MiniMax H3 Audio T8：打开音频工作流' })).toHaveAttribute(
-      'href',
-      'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
-    )
-    expect(screen.queryByRole('link', { name: /模型权重/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('餐厅时间冻结与逆向复原')).not.toBeInTheDocument()
+    await waitFor(() => expect(createTweet).toHaveBeenCalledWith(
+      '2085297962977227011',
+      expect.any(HTMLElement),
+      expect.objectContaining({ lang: 'en' }),
+    ))
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,88 +1,221 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowUpRight,
   Check,
+  ChevronDown,
   ChevronRight,
   Clipboard,
   Clock3,
   Code2,
-  FileCode2,
+  Languages,
   Search,
   SlidersHorizontal,
   Sparkles,
   X,
 } from 'lucide-react'
 import rawCases from '../data/cases.json'
-import rawTemplates from '../data/templates.json'
+import {
+  casePath,
+  casePrompt,
+  caseSummary,
+  caseTitle,
+  copy,
+  metadataValue,
+  modeLabel,
+  modelLabel,
+  pathFor,
+  provenanceLabel,
+  resolveRoute,
+  sourceLabel,
+  taxonomyLabel,
+  type AppPage,
+  type Language,
+} from './i18n'
 import type { CaseMode, VideoCase } from './types'
 import { XPostEmbed } from './XPostEmbed'
 
 const cases = rawCases as VideoCase[]
-const templates = rawTemplates as PromptTemplate[]
 const modes: Array<'ALL' | CaseMode> = ['ALL', 'T2VA', 'FL2VA', 'Ref2VA', 'Unknown']
 const allCategories = [...new Set(cases.map((item) => item.category))]
 const allStyles = [...new Set(cases.flatMap((item) => item.styles))]
 const allScenes = [...new Set(cases.flatMap((item) => item.scenes))]
 
-interface PromptTemplate {
-  id: string
-  title: string
-  titleEn: string
-  mode: CaseMode
-  useWhen: string
-  sourceCaseId: string
-  sections: string[]
-  template: string
-}
-
-const modeCopy: Record<(typeof modes)[number], string> = {
-  ALL: '全部样例',
-  T2VA: '文字生视频',
-  FL2VA: '首尾帧',
-  Ref2VA: '全模态参考',
-  Unknown: '模式待确认',
-}
-
 const toolkitResources = [
   {
     code: 'R01',
-    kind: 'OFFICIAL / SKILLS',
+    kind: { zh: '官方 / AGENT SKILLS', en: 'OFFICIAL / AGENT SKILLS' },
     title: 'MiniMax-AI / MiniMax-H3',
-    description: '官方仓库与本地部署入口。内置 9 个 Agent Skill；先装 h3-prompt-writing，让 Claude / Codex 按镜头、对白与环境声组织 H3 提示词。',
+    description: {
+      zh: '官方仓库与本地部署入口。内置 9 个 Agent Skill；先装 h3-prompt-writing，让 Claude / Codex 按镜头、对白与环境声组织 H3 提示词。',
+      en: 'The official repository and local deployment entry point. Its nine Agent Skills include h3-prompt-writing for structuring shots, dialogue, and environmental audio with Claude or Codex.',
+    },
     tags: ['9 Skills', 'Prompt Writing', 'Local Deploy'],
     url: 'https://github.com/MiniMax-AI/MiniMax-H3',
-    action: '打开官方仓库',
+    action: { zh: '打开官方仓库', en: 'Open official repository' },
   },
   {
     code: 'R02',
-    kind: 'ACCELERATION / LORA',
+    kind: { zh: '加速 / LORA', en: 'ACCELERATION / LORA' },
     title: 'MiniMax-H3 Turbo LoRA',
-    description: '将常规约 20 步采样压缩到 4–8 步并保留同步立体声音频。4 步用于快速预览，v4 版本在 6–8 步通常更稳。',
+    description: {
+      zh: '将常规约 20 步采样压缩到 4–8 步并保留同步立体声音频。4 步用于快速预览，v4 版本在 6–8 步通常更稳。',
+      en: 'Compresses the usual 20-step sampling path to four to eight steps while retaining synchronized stereo audio. Four steps suit previews; v4 is generally steadier at six to eight.',
+    },
     tags: ['4–8 Steps', 'Audio + Video', 'ComfyUI'],
     url: 'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
-    action: '打开 Hugging Face',
+    action: { zh: '打开 Hugging Face', en: 'Open on Hugging Face' },
   },
   {
     code: 'R03',
-    kind: 'LONG VIDEO / CONTEXT',
+    kind: { zh: '长视频 / 上下文', en: 'LONG VIDEO / CONTEXT' },
     title: 'ComfyUI H3 Motion Context',
-    description: '用于多段 H3 视频续接，把上一段的画面与音频上下文带入下一段，减少片段连接处的动作、节奏和声音断裂。',
+    description: {
+      zh: '用于多段 H3 视频续接，把上一段的画面与音频上下文带入下一段，减少连接处的动作、节奏和声音断裂。',
+      en: 'Carries visual and audio context from one H3 clip into the next, reducing breaks in motion, rhythm, and sound across longer sequences.',
+    },
     tags: ['Clip Chaining', 'Motion Context', 'Audio Continuity'],
     url: 'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
-    action: '打开续接节点',
+    action: { zh: '打开续接节点', en: 'Open continuation nodes' },
   },
   {
     code: 'R04',
-    kind: 'AUDIO / WORKFLOWS',
+    kind: { zh: '音频 / 工作流', en: 'AUDIO / WORKFLOWS' },
     title: 'MiniMax H3 Audio T8',
-    description: '面向 ComfyUI 原生 H3 的 14 节点扩展，覆盖音频条件、双时钟采样、混音、裁切、预检和 Ref2VA 参考，并附 API 与前端工作流。',
+    description: {
+      zh: '面向 ComfyUI 原生 H3 的 14 节点扩展，覆盖音频条件、双时钟采样、混音、裁切、预检和 Ref2VA 参考，并附 API 与前端工作流。',
+      en: 'A 14-node extension for native H3 in ComfyUI, covering audio conditioning, dual-clock sampling, mixing, trimming, preflight checks, Ref2VA references, API use, and frontend workflows.',
+    },
     tags: ['14 Nodes', 'Dual Clock', 'Audio Control'],
     url: 'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
-    action: '打开音频工作流',
+    action: { zh: '打开音频工作流', en: 'Open audio workflows' },
   },
 ]
 
 function App() {
+  const route = resolveRoute(window.location.pathname)
+  const language = route.language
+  const t = copy[language]
+  const pageDescription = route.page === 'toolkit'
+    ? t.toolkit.description
+    : route.page === 'faq'
+      ? t.faq.description
+      : t.siteDescription
+  const pageTitle = route.page === 'home'
+    ? t.siteTitle
+    : route.page === 'toolkit'
+      ? language === 'zh'
+        ? 'MiniMax H3 工具链与部署资源 — H3 Field Notes'
+        : 'MiniMax H3 Toolkit and Deployment Resources — H3 Field Notes'
+      : language === 'zh'
+        ? 'MiniMax H3 视频案例库常见问题 — H3 Field Notes'
+        : 'MiniMax H3 Video Library FAQ — H3 Field Notes'
+
+  useEffect(() => {
+    document.documentElement.lang = t.htmlLang
+    document.title = pageTitle
+    document.querySelector<HTMLMetaElement>('meta[name="description"]')?.setAttribute('content', pageDescription)
+  }, [pageDescription, pageTitle, t.htmlLang])
+
+  return (
+    <main id="top">
+      <div className="grain" aria-hidden="true" />
+      <Header language={language} page={route.page} />
+      {route.page === 'home' && <HomePage language={language} />}
+      {route.page === 'toolkit' && <ToolkitPage language={language} />}
+      {route.page === 'faq' && <FaqPage language={language} />}
+      <Footer language={language} />
+    </main>
+  )
+}
+
+function Header({ language, page }: { language: Language; page: AppPage }) {
+  const t = copy[language]
+  const otherLanguage: Language = language === 'zh' ? 'en' : 'zh'
+
+  return (
+    <header className="site-header-wrap">
+      <div className="shell site-header">
+        <a className="brand" href={pathFor(language, 'home')} aria-label="H3 Field Notes">
+          H3<span>/FN</span>
+        </a>
+        <nav aria-label={language === 'zh' ? '主导航' : 'Primary navigation'}>
+          <a href={pathFor(language, 'home')} aria-current={page === 'home' ? 'page' : undefined}>{t.nav.cases}</a>
+          <a href={pathFor(language, 'toolkit')} aria-current={page === 'toolkit' ? 'page' : undefined}>{t.nav.toolkit}</a>
+          <a href={pathFor(language, 'faq')} aria-current={page === 'faq' ? 'page' : undefined}>{t.nav.faq}</a>
+        </nav>
+        <div className="header-actions">
+          <a
+            className="language-button"
+            href={pathFor(otherLanguage, page)}
+            aria-label={language === 'zh' ? '切换到英文' : 'Switch to Chinese'}
+          >
+            <Languages size={14} aria-hidden="true" /> {t.nav.language}
+          </a>
+          <a
+            className="source-button"
+            href="https://github.com/SkyNotSilent/awesome-minimax-h3"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Code2 size={15} aria-hidden="true" /> <span>{t.nav.source}</span>
+          </a>
+        </div>
+      </div>
+    </header>
+  )
+}
+
+function IntroSplash({ language }: { language: Language }) {
+  const [phase, setPhase] = useState<'visible' | 'leaving' | 'gone'>('visible')
+  const t = copy[language].intro
+
+  useEffect(() => {
+    document.body.classList.add('intro-open')
+    const leaveTimer = window.setTimeout(() => setPhase('leaving'), 1_600)
+    return () => {
+      window.clearTimeout(leaveTimer)
+      document.body.classList.remove('intro-open')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (phase === 'gone') {
+      document.body.classList.remove('intro-open')
+      return
+    }
+    if (phase !== 'leaving') return
+    const removeTimer = window.setTimeout(() => setPhase('gone'), 500)
+    return () => window.clearTimeout(removeTimer)
+  }, [phase])
+
+  const skip = () => {
+    setPhase('leaving')
+  }
+
+  if (phase === 'gone') return null
+
+  return (
+    <aside className={`intro-splash ${phase === 'leaving' ? 'is-leaving' : ''}`} aria-label={t.description}>
+      <div className="intro-grid" aria-hidden="true" />
+      <div className="intro-topline">
+        <span><i /> {t.kicker}</span>
+        <button type="button" onClick={skip}>{t.skip} <ArrowUpRight size={13} /></button>
+      </div>
+      <div className="intro-wordmark" aria-hidden="true">
+        <span>{t.lineOne}</span>
+        <strong>{t.lineTwo}</strong>
+      </div>
+      <div className="intro-bottomline">
+        <p>{t.description}</p>
+        <div className="intro-ready"><span /> {t.ready} · {cases.length}</div>
+      </div>
+      <div className="intro-progress" aria-hidden="true"><span /></div>
+    </aside>
+  )
+}
+
+function HomePage({ language }: { language: Language }) {
+  const t = copy[language]
   const [activeMode, setActiveMode] = useState<(typeof modes)[number]>('ALL')
   const [activeCategory, setActiveCategory] = useState('ALL')
   const [activeStyle, setActiveStyle] = useState('ALL')
@@ -97,142 +230,89 @@ function App() {
       const matchesCategory = activeCategory === 'ALL' || item.category === activeCategory
       const matchesStyle = activeStyle === 'ALL' || item.styles.includes(activeStyle)
       const matchesScene = activeScene === 'ALL' || item.scenes.includes(activeScene)
-      const haystack = [
-        item.title,
-        item.titleEn,
-        item.summary,
-        item.prompt,
-        item.category,
-        ...item.tags,
-        ...item.styles,
-        ...item.scenes,
-      ]
-        .join(' ')
-        .toLowerCase()
-      return matchesMode && matchesCategory && matchesStyle && matchesScene && (!needle || haystack.includes(needle))
+      const haystack = language === 'zh'
+        ? [item.title, item.summary, item.prompt, ...item.tags, item.category, ...item.styles, ...item.scenes]
+        : [item.titleEn, item.summaryEn, casePrompt(item, language), item.category, ...item.styles, ...item.scenes]
+      return matchesMode && matchesCategory && matchesStyle && matchesScene
+        && (!needle || haystack.join(' ').toLowerCase().includes(needle))
     })
-  }, [activeCategory, activeMode, activeScene, activeStyle, query])
+  }, [activeCategory, activeMode, activeScene, activeStyle, language, query])
 
-  useEffect(() => {
-    if (!selected) return
-    const close = (event: KeyboardEvent) => event.key === 'Escape' && setSelected(null)
-    document.body.classList.add('modal-open')
-    window.addEventListener('keydown', close)
-    return () => {
-      document.body.classList.remove('modal-open')
-      window.removeEventListener('keydown', close)
-    }
-  }, [selected])
+  const advancedCount = [activeCategory, activeStyle, activeScene].filter((value) => value !== 'ALL').length
 
   return (
-    <main id="top">
-      <div className="grain" aria-hidden="true" />
-      <Header />
-
-      <section className="hero shell">
-        <div className="hero-kicker reveal reveal-1">
-          <span className="live-dot" /> COMMUNITY RESEARCH INDEX / 2026
-        </div>
-        <h1 className="reveal reveal-2">
-          H3 <span>FIELD</span>
-          <br />NOTES<sup>β</sup>
-        </h1>
-        <div className="hero-bottom reveal reveal-3">
-          <p>
-            MiniMax H3 的社区实验档案。收录真实视频、完整提示词、输入方式与可复现工作流。
-          </p>
-          <div className="hero-stats" aria-label="项目统计">
-            <Stat value={String(cases.length).padStart(2, '0')} label="公开案例" />
-            <Stat value={String(templates.length).padStart(2, '0')} label="提示词模板" />
-            <Stat value="24" label="帧 / 秒" />
-          </div>
-        </div>
-      </section>
-
+    <>
+      <IntroSplash language={language} />
       <section className="catalog shell" id="catalog">
         <div className="catalog-bar">
-          <div>
-            <p className="section-index">01 / 案例索引</p>
-            <h2>观察。拆解。复现。</h2>
+          <div className="catalog-heading">
+            <p className="section-index">{t.catalog.index}</p>
+            <h1>{t.catalog.title}</h1>
+            <p>{t.catalog.description}</p>
           </div>
           <label className="search-box">
             <Search size={17} aria-hidden="true" />
-            <span className="sr-only">搜索案例</span>
+            <span className="sr-only">{t.catalog.searchLabel}</span>
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="搜索提示词、场景、标签…"
+              placeholder={t.catalog.searchPlaceholder}
             />
             {query && (
-              <button onClick={() => setQuery('')} aria-label="清除搜索">
+              <button type="button" onClick={() => setQuery('')} aria-label={t.catalog.clearSearch}>
                 <X size={15} />
               </button>
             )}
           </label>
         </div>
 
-        <div className="filter-panel" aria-label="案例筛选">
-          <div className="filter-label">
-            <SlidersHorizontal size={16} aria-hidden="true" /> FILTER INDEX
+        <div className="primary-filter" aria-label={t.catalog.filterLabel}>
+          <div className="filter-label"><SlidersHorizontal size={15} aria-hidden="true" /> {t.catalog.mode}</div>
+          <div className="mode-filter">
+            {modes.map((mode) => (
+              <button
+                type="button"
+                key={mode}
+                className={mode === activeMode ? 'active' : ''}
+                onClick={() => setActiveMode(mode)}
+              >
+                <span>{mode === 'ALL' ? '00' : mode}</span>{modeLabel(mode, language)}
+              </button>
+            ))}
           </div>
-          <FilterGroup
-            label="生成模式"
-            options={modes}
-            value={activeMode}
-            onChange={(value) => setActiveMode(value as (typeof modes)[number])}
-            format={(value) => modeCopy[value as (typeof modes)[number]]}
-          />
-          <FilterGroup label="内容分类" options={['ALL', ...allCategories]} value={activeCategory} onChange={setActiveCategory} />
-          <FilterGroup label="视觉风格" options={['ALL', ...allStyles]} value={activeStyle} onChange={setActiveStyle} />
-          <FilterGroup label="场景" options={['ALL', ...allScenes]} value={activeScene} onChange={setActiveScene} />
         </div>
 
-        <div className="case-grid" aria-live="polite">
+        <details className="advanced-filters">
+          <summary>
+            <span><SlidersHorizontal size={14} /> {advancedCount ? t.catalog.advancedActive : t.catalog.advanced}</span>
+            <span>{advancedCount || '—'} <ChevronDown size={14} /></span>
+          </summary>
+          <div className="filter-panel">
+            <FilterGroup language={language} kind="category" label={t.catalog.category} options={['ALL', ...allCategories]} value={activeCategory} onChange={setActiveCategory} />
+            <FilterGroup language={language} kind="style" label={t.catalog.style} options={['ALL', ...allStyles]} value={activeStyle} onChange={setActiveStyle} />
+            <FilterGroup language={language} kind="scene" label={t.catalog.scene} options={['ALL', ...allScenes]} value={activeScene} onChange={setActiveScene} />
+          </div>
+        </details>
+
+        <div className="catalog-count" aria-live="polite">
+          <span>{String(filtered.length).padStart(2, '0')}</span> {t.catalog.resultUnit}
+        </div>
+
+        <div className="case-grid">
           {filtered.map((item, index) => (
-            <CaseCard key={item.id} item={item} index={index} onOpen={() => setSelected(item)} />
+            <CaseCard key={item.id} item={item} index={index} language={language} onOpen={() => setSelected(item)} />
           ))}
         </div>
 
         {filtered.length === 0 && (
           <div className="empty-state">
-            <span>NO MATCHES</span>
-            <p>没有找到匹配案例，换一个关键词或模式试试。</p>
+            <span>{t.catalog.noMatchesEyebrow}</span>
+            <p>{t.catalog.noMatches}</p>
           </div>
         )}
       </section>
-
-      <Templates />
-      <Toolkit />
-      <Method />
-      <FAQ />
-      <Footer />
-      {selected && <CaseDialog item={selected} onClose={() => setSelected(null)} />}
-    </main>
-  )
-}
-
-function Header() {
-  return (
-    <header className="shell site-header reveal reveal-1">
-      <a className="brand" href="#top" aria-label="H3 Field Notes 首页">
-        H3<span>/FN</span>
-      </a>
-      <nav>
-        <a href="#catalog">案例</a>
-        <a href="#templates">模板</a>
-        <a href="#toolkit">工具链</a>
-        <a href="#method">收录方式</a>
-        <a href="#faq">常见问题</a>
-      </nav>
-      <a
-        className="source-button"
-        href="https://github.com/SkyNotSilent/awesome-minimax-h3"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <Code2 size={16} /> SOURCE
-      </a>
-    </header>
+      {selected && <CaseDialog item={selected} language={language} onClose={() => setSelected(null)} />}
+    </>
   )
 }
 
@@ -241,21 +321,23 @@ function FilterGroup({
   options,
   value,
   onChange,
-  format = (option) => (option === 'ALL' ? '全部' : option),
+  language,
+  kind,
 }: {
   label: string
   options: readonly string[]
   value: string
   onChange: (value: string) => void
-  format?: (option: string) => string
+  language: Language
+  kind: 'category' | 'style' | 'scene'
 }) {
   return (
     <div className="filter-group">
       <strong>{label}</strong>
       <div>
         {options.map((option) => (
-          <button key={option} className={option === value ? 'active' : ''} onClick={() => onChange(option)}>
-            {format(option)}
+          <button type="button" key={option} className={option === value ? 'active' : ''} onClick={() => onChange(option)}>
+            {taxonomyLabel(option, language, kind)}
           </button>
         ))}
       </div>
@@ -263,33 +345,33 @@ function FilterGroup({
   )
 }
 
-function Stat({ value, label }: { value: string; label: string }) {
-  return (
-    <div className="stat">
-      <strong>{value}</strong>
-      <span>{label}</span>
-    </div>
-  )
-}
-
 function CaseCard({
   item,
   index,
+  language,
   onOpen,
 }: {
   item: VideoCase
   index: number
+  language: Language
   onOpen: () => void
 }) {
+  const t = copy[language].card
+  const title = caseTitle(item, language)
+  const chips = [
+    item.styles[0] && taxonomyLabel(item.styles[0], language, 'style'),
+    item.scenes[0] && taxonomyLabel(item.scenes[0], language, 'scene'),
+  ].filter(Boolean)
+
   return (
     <article className="case-card" style={{ '--order': index } as React.CSSProperties}>
-      <button className="media" onClick={onOpen} aria-label={`查看 ${item.title} 详情`}>
+      <button className="media" type="button" onClick={onOpen} aria-label={t.open(title)}>
         {item.mediaUrl ? (
           <video src={item.mediaUrl} poster={item.posterUrl} muted loop playsInline preload="metadata" />
         ) : (
           <img
             src={item.posterUrl}
-            alt={`${item.title} 视频封面`}
+            alt={t.cover(title)}
             loading="lazy"
             decoding="async"
             onError={(event) => {
@@ -300,245 +382,163 @@ function CaseCard({
         )}
         <span className="media-scan" aria-hidden="true" />
         <span className="case-number">{String(index + 1).padStart(2, '0')}</span>
-        <span className="duration">
-          <Clock3 size={12} /> {item.duration}s
-        </span>
+        <span className="duration"><Clock3 size={12} /> {item.duration}s</span>
         <span className="play-mark">
-          {item.mediaUrl || item.sourceType === 'x' ? 'PLAY' : 'VIEW'} <ChevronRight size={14} />
+          {item.mediaUrl || item.sourceType === 'x' ? t.play : t.view} <ChevronRight size={14} />
         </span>
       </button>
       <div className="case-meta">
         <div className="mode-line">
-          <span>{item.mode} / {item.category}</span>
-          {item.verified && (
-            <span className="verified">
-              <Check size={11} /> 官方可复现
-            </span>
-          )}
-          {!item.verified && item.sourceType === 'x' && (
-            <span className="verified community-source">
-              <ArrowUpRight size={11} /> X 社区
-            </span>
-          )}
+          <span>{item.mode} / {taxonomyLabel(item.category, language, 'category')}</span>
+          {item.verified ? (
+            <span className="verified"><Check size={11} /> {t.verified}</span>
+          ) : item.sourceType === 'x' ? (
+            <span className="verified community-source"><ArrowUpRight size={11} /> {t.community}</span>
+          ) : null}
         </div>
-        <a className="case-title" href={`/cases/${item.id}/`}>
-          <h3>{item.title}</h3>
-          <p>{item.titleEn}</p>
+        <a className="case-title" href={casePath(language, item.id)}>
+          <h2>{title}</h2>
         </a>
         <div className="tags">
-          {item.tags.slice(0, 3).map((tag) => (
-            <span key={tag}>#{tag}</span>
+          {chips.map((tag) => <span key={tag}>#{tag}</span>)}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function PageHero({ index, title, description }: { index: string; title: string; description: string }) {
+  return (
+    <section className="page-hero shell">
+      <p className="section-index">{index}</p>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <div className="page-hero-rule" aria-hidden="true"><span /></div>
+    </section>
+  )
+}
+
+function ToolkitPage({ language }: { language: Language }) {
+  const t = copy[language].toolkit
+
+  return (
+    <div className="standalone-page toolkit-page">
+      <PageHero index={t.index} title={t.title} description={t.description} />
+      <section className="toolkit shell" aria-label={copy[language].nav.toolkit}>
+        <div className="toolkit-grid">
+          {toolkitResources.map((item) => (
+            <a className="resource-card" href={item.url} target="_blank" rel="noreferrer" key={item.code} aria-label={`${item.title}: ${item.action[language]}`}>
+              <div className="resource-topline"><span>{item.code}</span><span>{item.kind[language]}</span></div>
+              <h2>{item.title}</h2>
+              <p>{item.description[language]}</p>
+              <div className="resource-tags">{item.tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
+              <div className="resource-action">{item.action[language]} <ArrowUpRight size={15} /></div>
+            </a>
           ))}
         </div>
-      </div>
-    </article>
-  )
-}
 
-function Templates() {
-  const [copied, setCopied] = useState<string | null>(null)
-
-  async function copyTemplate(item: PromptTemplate) {
-    await navigator.clipboard.writeText(item.template)
-    setCopied(item.id)
-    window.setTimeout(() => setCopied(null), 1600)
-  }
-
-  return (
-    <section className="templates shell" id="templates">
-      <div className="templates-intro">
-        <p className="section-index">02 / PROMPT AS CODE</p>
-        <h2>从单个案例，<br />提炼可复用镜头协议。</h2>
-        <p>每个模板都能追溯到已核验案例；变量可替换，来源不会丢。</p>
-      </div>
-      <div className="template-list">
-        {templates.map((item) => (
-          <article key={item.id}>
-            <div className="template-code">{item.id}</div>
-            <div className="template-body">
-              <div className="template-mode">{item.mode}</div>
-              <h3>{item.title}</h3>
-              <p className="template-en">{item.titleEn}</p>
-              <p>{item.useWhen}</p>
-              <div className="template-sections">
-                {item.sections.map((section) => <span key={section}>{section}</span>)}
-              </div>
-            </div>
-            <button onClick={() => copyTemplate(item)}>
-              {copied === item.id ? <Check size={15} /> : <FileCode2 size={15} />}
-              {copied === item.id ? '已复制' : '复制模板'}
-            </button>
+        <div className="toolkit-notes">
+          <article className="speed-note">
+            <div className="note-label">{t.speedLabel}</div>
+            <h2>{t.speedTitle}</h2>
+            <p>{t.speedBody}</p>
+            <small>{t.speedFootnote}</small>
           </article>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-function Toolkit() {
-  return (
-    <section className="toolkit shell" id="toolkit">
-      <div className="toolkit-heading">
-        <div>
-          <p className="section-index">03 / H3 FIELD KIT</p>
-          <h2>从提示词，<br />一路接到成片。</h2>
+          <article className="pipeline-note">
+            <div className="note-label">{t.pipelineLabel}</div>
+            <div className="pipeline-flow" aria-label={t.pipelineLabel}>
+              <div><span>01</span><strong>AGENT</strong><small>{t.pipeline[0]}</small></div>
+              <ChevronRight size={18} aria-hidden="true" />
+              <div><span>02</span><strong>COMFYUI API</strong><small>{t.pipeline[1]}</small></div>
+              <ChevronRight size={18} aria-hidden="true" />
+              <div><span>03</span><strong>REMOTION</strong><small>{t.pipeline[2]}</small></div>
+            </div>
+          </article>
         </div>
-        <p>
-          不只给模型权重。这里整理真正会影响落地效率的官方 Skill、加速 LoRA、长视频续接与音视频工作流。
-        </p>
-      </div>
-
-      <div className="toolkit-grid">
-        {toolkitResources.map((item) => (
-          <a
-            className="resource-card"
-            href={item.url}
-            target="_blank"
-            rel="noreferrer"
-            key={item.code}
-            aria-label={`${item.title}：${item.action}`}
-          >
-            <div className="resource-topline">
-              <span>{item.code}</span>
-              <span>{item.kind}</span>
-            </div>
-            <h3>{item.title}</h3>
-            <p>{item.description}</p>
-            <div className="resource-tags">
-              {item.tags.map((tag) => <span key={tag}>{tag}</span>)}
-            </div>
-            <div className="resource-action">
-              {item.action} <ArrowUpRight size={15} />
-            </div>
-          </a>
-        ))}
-      </div>
-
-      <div className="toolkit-notes">
-        <article className="speed-note">
-          <div className="note-label">FIELD NOTE / 速度组合</div>
-          <h3>少叠插件，先把采样链路跑稳。</h3>
-          <p>
-            实战优先尝试 <strong>Turbo LoRA + SageAttention</strong>。4 步适合预览，6–8 步用于成片；EasyCache 更适合原生 20 步工作流，不建议和 4 步 Turbo 叠加。端到端速度仍会受到 VAE 解码与视频封装影响。
-          </p>
-          <small>生态观察：当前 H3 LoRA 热点集中在加速，人物与画风训练仍处于早期。</small>
-        </article>
-
-        <article className="pipeline-note">
-          <div className="note-label">NEXT PIPELINE / 无人出片</div>
-          <div className="pipeline-flow" aria-label="下一步自动化路线">
-            <div><span>01</span><strong>AGENT</strong><small>h3-prompt-writing</small></div>
-            <ChevronRight size={18} aria-hidden="true" />
-            <div><span>02</span><strong>COMFYUI API</strong><small>生成音视频</small></div>
-            <ChevronRight size={18} aria-hidden="true" />
-            <div><span>03</span><strong>REMOTION</strong><small>自动剪辑与交付</small></div>
-          </div>
-        </article>
-      </div>
-    </section>
+      </section>
+    </div>
   )
 }
 
-function Method() {
+function FaqPage({ language }: { language: Language }) {
+  const t = copy[language].faq
+
   return (
-    <section className="method shell" id="method">
-      <div className="method-heading">
-        <p className="section-index">04 / 收录方式</p>
-        <h2>不是热度榜。<br />是可验证的实验记录。</h2>
-      </div>
-      <div className="method-steps">
-        <MethodStep number="A" title="发现" text="监控 X 关键词与重点创作者，归档原帖地址和公开元数据，并通过官方嵌入播放器站内展示。" />
-        <MethodStep number="B" title="低成本核验" text="规则先过滤，MiMo V2.5 Pro 处理文本；只有入围视频才交给 MiMo V2.5 多模态核验。" />
-        <MethodStep number="C" title="人工归档" text="候选不会超时自动发布。审核合并后，再同步网站、GitHub 目录与 Agent Skill。" />
-      </div>
-    </section>
+    <div className="standalone-page faq-page">
+      <PageHero index={t.index} title={t.title} description={t.description} />
+      <section className="faq shell" aria-label={copy[language].nav.faq}>
+        <div className="faq-list">
+          {t.items.map(([question, answer], index) => (
+            <article key={question}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <div><h2>{question}</h2><p>{answer}</p></div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
   )
 }
 
-function MethodStep({ number, title, text }: { number: string; title: string; text: string }) {
-  return (
-    <article>
-      <span>{number}</span>
-      <div>
-        <h3>{title}</h3>
-        <p>{text}</p>
-      </div>
-    </article>
-  )
-}
-
-function FAQ() {
-  return (
-    <section className="faq shell" id="faq">
-      <div className="faq-heading">
-        <p className="section-index">05 / FAQ</p>
-        <h2>关于 MiniMax H3<br />视频提示词案例库</h2>
-      </div>
-      <div className="faq-list">
-        <article>
-          <h3>MiniMax H3 和 Hailuo 3.0 是什么关系？</h3>
-          <p>本项目把 MiniMax H3 作为模型名称，并同时覆盖社区常用的 Hailuo 3.0 / 海螺 3.0 检索表达，方便找到同一技术生态下的视频案例。</p>
-        </article>
-        <article>
-          <h3>这里有哪些 AI 视频生成模式？</h3>
-          <p>当前收录 T2VA 文字生视频、FL2VA 首尾帧条件视频，以及 Ref2VA 全模态参考视频；案例可包含图像、视频、声音、对白和时间轴控制。</p>
-        </article>
-        <article>
-          <h3>X 上发现的案例会自动发布吗？</h3>
-          <p>不会。浏览器任务只写入候选队列，先核对模型、作者、原帖、提示词来源和版权风险，再由人工批准进入公开案例库。</p>
-        </article>
-      </div>
-    </section>
-  )
-}
-
-function CaseDialog({ item, onClose }: { item: VideoCase; onClose: () => void }) {
+function CaseDialog({ item, language, onClose }: { item: VideoCase; language: Language; onClose: () => void }) {
   const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
+  const t = copy[language].dialog
+  const title = caseTitle(item, language)
+  const prompt = casePrompt(item, language)
+
+  useEffect(() => {
+    mountedRef.current = true
+    const close = (event: KeyboardEvent) => event.key === 'Escape' && onClose()
+    document.body.classList.add('modal-open')
+    window.addEventListener('keydown', close)
+    return () => {
+      mountedRef.current = false
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+      document.body.classList.remove('modal-open')
+      window.removeEventListener('keydown', close)
+    }
+  }, [onClose])
 
   async function copyPrompt() {
-    await navigator.clipboard.writeText(item.prompt)
+    await navigator.clipboard.writeText(prompt)
+    if (!mountedRef.current) return
     setCopied(true)
-    window.setTimeout(() => setCopied(false), 1800)
+    if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+    copyTimerRef.current = window.setTimeout(() => setCopied(false), 1_800)
   }
 
   return (
     <div className="dialog-backdrop" role="presentation" onMouseDown={onClose}>
-      <section
-        className="case-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="dialog-title"
-        onMouseDown={(event) => event.stopPropagation()}
-      >
-        <button className="dialog-close" onClick={onClose} aria-label="关闭详情">
-          <X size={19} />
-        </button>
+      <section className="case-dialog" role="dialog" aria-modal="true" aria-labelledby="dialog-title" onMouseDown={(event) => event.stopPropagation()}>
+        <button className="dialog-close" type="button" onClick={onClose} aria-label={t.close}><X size={19} /></button>
         <div className="dialog-video">
           {item.mediaUrl ? (
             <video src={item.mediaUrl} poster={item.posterUrl} controls autoPlay playsInline />
           ) : (
-            <XPostEmbed sourceUrl={item.sourceUrl} title={item.title} posterUrl={item.posterUrl} />
+            <XPostEmbed sourceUrl={item.sourceUrl} title={title} posterUrl={item.posterUrl} language={language} />
           )}
         </div>
         <div className="dialog-copy">
           <div className="dialog-eyebrow">
             <span>{item.mode}</span>
-            <span>{item.resolution}</span>
-            <span>{item.aspectRatio}</span>
-            <span>{item.duration} 秒</span>
+            <span>{metadataValue(item.resolution, language)}</span>
+            <span>{metadataValue(item.aspectRatio, language)}</span>
+            <span>{item.duration} {t.seconds}</span>
           </div>
-          <h2 id="dialog-title">{item.title}</h2>
-          <p className="summary">{item.summary}</p>
+          <h2 id="dialog-title">{title}</h2>
+          <p className="summary">{caseSummary(item, language)}</p>
+          <div className="case-model-line">{modelLabel(item, language)}</div>
           <div className="prompt-heading">
-            <span>提示词记录 / PROMPT RECORD · {item.promptProvenance}</span>
-            <button onClick={copyPrompt}>
-              {copied ? <Check size={14} /> : <Clipboard size={14} />}
-              {copied ? '已复制' : '复制'}
+            <span>{t.prompt} · {provenanceLabel(item.promptProvenance, language)}</span>
+            <button type="button" onClick={copyPrompt}>
+              {copied ? <Check size={14} /> : <Clipboard size={14} />}{copied ? t.copied : t.copy}
             </button>
           </div>
-          <pre>{item.prompt}</pre>
+          <pre>{prompt}</pre>
           <a className="original-link" href={item.sourceUrl} target="_blank" rel="noreferrer">
-            查看原始来源 · {item.sourceLabel} <ArrowUpRight size={15} />
+            {t.source} · {sourceLabel(item, language)} <ArrowUpRight size={15} />
           </a>
         </div>
       </section>
@@ -546,13 +546,12 @@ function CaseDialog({ item, onClose }: { item: VideoCase; onClose: () => void })
   )
 }
 
-function Footer() {
+function Footer({ language }: { language: Language }) {
+  const t = copy[language].footer
   return (
     <footer className="shell">
-      <div className="footer-mark">
-        <Sparkles size={16} /> OPEN COMMUNITY ARCHIVE
-      </div>
-      <p>仅收录公开来源；版权归原作者所有。发现错误或希望移除内容，请提交 Issue。</p>
+      <div className="footer-mark"><Sparkles size={16} /> {t.mark}</div>
+      <p>{t.note}</p>
       <span>H3/FN — 2026</span>
     </footer>
   )

--- a/src/XPostEmbed.test.tsx
+++ b/src/XPostEmbed.test.tsx
@@ -10,6 +10,7 @@ afterEach(() => {
   cleanup()
   vi.useRealTimers()
   delete window.twttr
+  document.querySelectorAll('script[data-x-widgets="true"]').forEach((script) => script.remove())
 })
 
 describe('XPostEmbed', () => {
@@ -49,5 +50,73 @@ describe('XPostEmbed', () => {
     fireEvent.click(screen.getByRole('button', { name: /重新加载/ }))
     await waitFor(() => expect(createTweet).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(screen.getByLabelText('餐厅时间冻结与逆向复原 X 原帖播放器')).toHaveAttribute('data-state', 'ready'))
+  })
+
+  it('replaces a failed widgets script before retrying', async () => {
+    render(<XPostEmbed sourceUrl={sourceUrl} title="餐厅时间冻结与逆向复原" posterUrl={posterUrl} />)
+
+    const firstScript = document.querySelector<HTMLScriptElement>('script[data-x-widgets="true"]')
+    expect(firstScript).toBeInTheDocument()
+
+    await act(async () => {
+      firstScript?.dispatchEvent(new Event('error'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('播放器加载失败')
+    expect(firstScript).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /重新加载/ }))
+    let replacementScript: HTMLScriptElement | null = null
+    await waitFor(() => {
+      replacementScript = document.querySelector<HTMLScriptElement>('script[data-x-widgets="true"]')
+      expect(replacementScript).toBeInTheDocument()
+      expect(replacementScript).not.toBe(firstScript)
+    })
+    await act(async () => {
+      replacementScript?.dispatchEvent(new Event('error'))
+      await Promise.resolve()
+    })
+  })
+
+  it('keeps every visible and accessible label in the selected language', async () => {
+    vi.useFakeTimers()
+    const createTweet = vi.fn(() => new Promise<HTMLElement | undefined>(() => {}))
+    window.twttr = { widgets: { createTweet } }
+
+    render(
+      <XPostEmbed
+        sourceUrl={sourceUrl}
+        title="Diner time freeze and rewind"
+        posterUrl={posterUrl}
+        language="en"
+      />,
+    )
+    await act(async () => Promise.resolve())
+
+    expect(screen.getByLabelText('Diner time freeze and rewind X post player')).toHaveAttribute('data-state', 'loading')
+    expect(screen.getByAltText('Diner time freeze and rewind video cover')).toHaveAttribute('src', posterUrl)
+    expect(screen.getByText('X post player')).toBeInTheDocument()
+    expect(screen.getByText('Media provided by X')).toBeInTheDocument()
+    expect(screen.getByText('Connecting to the X player')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open the original post on X if the player is unavailable/ })).toHaveAttribute(
+      'href',
+      sourceUrl,
+    )
+
+    act(() => vi.advanceTimersByTime(6_000))
+    expect(screen.getByText('X is responding slowly')).toBeInTheDocument()
+
+    act(() => vi.advanceTimersByTime(14_000))
+    expect(screen.getByRole('alert')).toHaveTextContent('Player failed to load')
+    expect(screen.getByRole('button', { name: 'Reload player' })).toBeInTheDocument()
+    expect(document.body).not.toHaveTextContent('播放器')
+    expect(document.body).not.toHaveTextContent('加载')
+    expect(createTweet).toHaveBeenCalledWith(
+      '2085297962977227011',
+      expect.any(HTMLElement),
+      expect.objectContaining({ lang: 'en' }),
+    )
   })
 })

--- a/src/XPostEmbed.tsx
+++ b/src/XPostEmbed.tsx
@@ -16,6 +16,7 @@ declare global {
 }
 
 type EmbedStatus = 'loading' | 'slow' | 'ready' | 'error'
+type EmbedLanguage = 'zh' | 'en'
 
 const SLOW_AFTER_MS = 6_000
 const FAIL_AFTER_MS = 20_000
@@ -50,6 +51,7 @@ function loadXWidgets() {
       if (settled) return
       settled = true
       cleanup()
+      script.remove()
       reject(new Error('X widgets failed to load'))
     }
 
@@ -77,21 +79,69 @@ function getPostId(sourceUrl: string) {
   return sourceUrl.match(/\/status\/(\d+)/)?.[1] ?? null
 }
 
-const stateCopy: Record<Exclude<EmbedStatus, 'ready'>, { eyebrow: string; title: string; detail: string }> = {
-  loading: {
-    eyebrow: 'CONNECTING',
-    title: '正在连接 X 播放器',
-    detail: '视频封面已就绪，播放器通常会在 2–8 秒内出现。',
+interface EmbedCopy {
+  playerLabel: (title: string) => string
+  posterAlt: (title: string) => string
+  barTitle: string
+  ready: string
+  providedBy: string
+  retry: string
+  fallback: string
+  states: Record<Exclude<EmbedStatus, 'ready'>, { eyebrow: string; title: string; detail: string }>
+}
+
+const copyByLanguage: Record<EmbedLanguage, EmbedCopy> = {
+  zh: {
+    playerLabel: (title) => `${title} X 原帖播放器`,
+    posterAlt: (title) => `${title} 视频封面`,
+    barTitle: 'X 原帖播放器',
+    ready: '播放器已就绪',
+    providedBy: '媒体由 X 提供',
+    retry: '重新加载',
+    fallback: '播放器受限时在 X 打开原帖',
+    states: {
+      loading: {
+        eyebrow: '正在连接',
+        title: '正在连接 X 播放器',
+        detail: '视频封面已就绪，播放器通常会在 2–8 秒内出现。',
+      },
+      slow: {
+        eyebrow: '响应较慢',
+        title: 'X 响应较慢，仍在加载',
+        detail: '网络或隐私设置可能延迟播放器；你可以继续等待。',
+      },
+      error: {
+        eyebrow: '加载失败',
+        title: '播放器加载失败',
+        detail: '当前网络或隐私设置阻止了 X 播放器，请重试或打开原帖。',
+      },
+    },
   },
-  slow: {
-    eyebrow: 'SLOW RESPONSE',
-    title: 'X 响应较慢，仍在加载',
-    detail: '网络或隐私设置可能延迟播放器；你可以继续等待。',
-  },
-  error: {
-    eyebrow: 'LOAD FAILED',
-    title: '播放器加载失败',
-    detail: '当前网络或隐私设置阻止了 X 播放器，请重试或打开原帖。',
+  en: {
+    playerLabel: (title) => `${title} X post player`,
+    posterAlt: (title) => `${title} video cover`,
+    barTitle: 'X post player',
+    ready: 'Player ready',
+    providedBy: 'Media provided by X',
+    retry: 'Reload player',
+    fallback: 'Open the original post on X if the player is unavailable',
+    states: {
+      loading: {
+        eyebrow: 'CONNECTING',
+        title: 'Connecting to the X player',
+        detail: 'The video cover is ready. The player usually appears within 2–8 seconds.',
+      },
+      slow: {
+        eyebrow: 'SLOW RESPONSE',
+        title: 'X is responding slowly',
+        detail: 'Network or privacy settings may delay the player. You can keep waiting.',
+      },
+      error: {
+        eyebrow: 'LOAD FAILED',
+        title: 'Player failed to load',
+        detail: 'Your network or privacy settings blocked the X player. Reload it or open the original post.',
+      },
+    },
   },
 }
 
@@ -99,10 +149,12 @@ export function XPostEmbed({
   sourceUrl,
   title,
   posterUrl,
+  language = 'zh',
 }: {
   sourceUrl: string
   title: string
   posterUrl: string
+  language?: EmbedLanguage
 }) {
   const targetRef = useRef<HTMLDivElement>(null)
   const postId = useMemo(() => getPostId(sourceUrl), [sourceUrl])
@@ -147,6 +199,7 @@ export function XPostEmbed({
         cards: 'visible',
         conversation: 'none',
         dnt: true,
+        lang: language === 'zh' ? 'zh-cn' : 'en',
         theme: 'dark',
       }))
       .then((embed) => settle(embed ? 'ready' : 'error'))
@@ -158,7 +211,7 @@ export function XPostEmbed({
       window.clearTimeout(failTimer)
       if (mount.parentNode === target) target.replaceChildren()
     }
-  }, [attempt, postId])
+  }, [attempt, language, postId])
 
   const retry = () => {
     setStatus('loading')
@@ -166,25 +219,26 @@ export function XPostEmbed({
   }
 
   const busy = status === 'loading' || status === 'slow'
-  const copy = status === 'ready' ? null : stateCopy[status]
+  const uiCopy = copyByLanguage[language]
+  const stateCopy = status === 'ready' ? null : uiCopy.states[status]
 
   return (
     <section
       className="x-embed-shell"
       data-state={status}
-      aria-label={`${title} X 原帖播放器`}
+      aria-label={uiCopy.playerLabel(title)}
       aria-busy={busy}
     >
       <div className="x-embed-bar">
-        <span><i aria-hidden="true" /> X 原帖播放器</span>
-        <small>{status === 'ready' ? '播放器已就绪' : '媒体由 X 提供'}</small>
+        <span><i aria-hidden="true" /> {uiCopy.barTitle}</span>
+        <small>{status === 'ready' ? uiCopy.ready : uiCopy.providedBy}</small>
       </div>
 
       <div className="x-embed-stage">
         <img
           className="x-embed-poster"
           src={posterUrl}
-          alt={`${title} 视频封面`}
+          alt={uiCopy.posterAlt(title)}
           onError={(event) => {
             event.currentTarget.onerror = null
             event.currentTarget.src = '/posters/x-community.svg'
@@ -193,7 +247,7 @@ export function XPostEmbed({
         <span className="x-embed-scrim" aria-hidden="true" />
         <div ref={targetRef} className="x-embed-target" />
 
-        {copy && (
+        {stateCopy && (
           <div
             className={`x-embed-status x-embed-status--${status}`}
             role={status === 'error' ? 'alert' : 'status'}
@@ -208,13 +262,13 @@ export function XPostEmbed({
               </span>
             )}
             <span className="x-embed-status-copy">
-              <small>{copy.eyebrow}</small>
-              <strong>{copy.title}</strong>
-              <span>{copy.detail}</span>
+              <small>{stateCopy.eyebrow}</small>
+              <strong>{stateCopy.title}</strong>
+              <span>{stateCopy.detail}</span>
             </span>
             {status === 'error' && (
               <button className="x-embed-retry" type="button" onClick={retry}>
-                <RefreshCw size={14} aria-hidden="true" /> 重新加载
+                <RefreshCw size={14} aria-hidden="true" /> {uiCopy.retry}
               </button>
             )}
           </div>
@@ -222,7 +276,7 @@ export function XPostEmbed({
       </div>
 
       <a className="x-embed-fallback" href={sourceUrl} target="_blank" rel="noreferrer">
-        播放器受限时在 X 打开原帖 <ArrowUpRight size={14} />
+        {uiCopy.fallback} <ArrowUpRight size={14} />
       </a>
     </section>
   )

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import rawCases from '../data/cases.json'
+import { metadataValue, modelLabel } from './i18n'
+import type { VideoCase } from './types'
+
+const cases = rawCases as VideoCase[]
+
+describe('case metadata localization', () => {
+  it('removes Chinese comparison and source-note metadata from English dialogs', () => {
+    const comparison = cases.find((item) => item.id === 'x-yukyuk-h3-seedance-same-prompt')
+    expect(comparison).toBeDefined()
+    expect(modelLabel(comparison!, 'en')).toBe('MiniMax H3 vs Seedance 2 (creator-identified)')
+    expect(metadataValue(comparison!.resolution, 'en')).toBe('Not specified in the original post')
+    expect(metadataValue('原帖', 'en')).toBe('Original post')
+  })
+})

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,310 @@
+import type { CaseMode, VideoCase } from './types'
+
+export type Language = 'zh' | 'en'
+export type AppPage = 'home' | 'toolkit' | 'faq'
+
+export interface AppRoute {
+  language: Language
+  page: AppPage
+}
+
+export function resolveRoute(pathname: string): AppRoute {
+  const segments = pathname.split('/').filter(Boolean)
+  const language: Language = segments[0] === 'en' ? 'en' : 'zh'
+  const pageSegment = segments[language === 'en' ? 1 : 0]
+  const page: AppPage = pageSegment === 'toolkit' || pageSegment === 'faq' ? pageSegment : 'home'
+  return { language, page }
+}
+
+export function pathFor(language: Language, page: AppPage) {
+  const prefix = language === 'en' ? '/en' : ''
+  return page === 'home' ? `${prefix}/` : `${prefix}/${page}/`
+}
+
+export function casePath(language: Language, id: string) {
+  return `${language === 'en' ? '/en' : ''}/cases/${encodeURIComponent(id)}/`
+}
+
+export const copy = {
+  zh: {
+    htmlLang: 'zh-CN',
+    siteTitle: 'Awesome MiniMax H3 — 视频案例库',
+    siteDescription: '可筛选、可追溯、可站内观看的 MiniMax H3 / Hailuo 3.0 视频案例库。',
+    nav: { cases: '案例', toolkit: '工具链', faq: '常见问题', source: '源码', language: 'EN' },
+    intro: {
+      kicker: 'COMMUNITY VIDEO ARCHIVE / 2026',
+      lineOne: 'H3',
+      lineTwo: 'FIELD NOTES',
+      description: 'MiniMax H3 社区视频实验档案',
+      ready: '案例界面已就绪',
+      skip: '跳过开场',
+    },
+    catalog: {
+      index: '01 / 案例索引',
+      title: '先看效果，再拆工作流。',
+      description: '公开视频、提示词来源和生成路径，点开封面即可站内观看。',
+      searchLabel: '搜索案例',
+      searchPlaceholder: '搜索案例、场景、工作流…',
+      clearSearch: '清除搜索',
+      filterLabel: '案例筛选',
+      mode: '生成模式',
+      advanced: '更多筛选',
+      advancedActive: '更多筛选 · 已启用',
+      category: '内容分类',
+      style: '视觉风格',
+      scene: '场景',
+      resultUnit: '条案例',
+      noMatchesEyebrow: '没有匹配结果',
+      noMatches: '换一个关键词或筛选条件试试。',
+    },
+    card: {
+      open: (title: string) => `查看 ${title} 详情`,
+      cover: (title: string) => `${title} 视频封面`,
+      play: '播放',
+      view: '查看',
+      verified: '官方可复现',
+      community: 'X 社区',
+    },
+    dialog: {
+      close: '关闭详情',
+      seconds: '秒',
+      prompt: '提示词记录',
+      copy: '复制',
+      copied: '已复制',
+      source: '查看原始来源',
+    },
+    toolkit: {
+      index: '02 / H3 工具链',
+      title: '从提示词，一路接到成片。',
+      description: '把真正影响落地效率的官方 Skill、加速 LoRA、长视频续接和音视频工作流放在一个独立工作台。',
+      speedLabel: '实战笔记 / 速度组合',
+      speedTitle: '少叠插件，先把采样链路跑稳。',
+      speedBody: '优先尝试 Turbo LoRA + SageAttention。4 步适合预览，6–8 步用于成片；EasyCache 更适合原生 20 步工作流，不建议和 4 步 Turbo 叠加。',
+      speedFootnote: '当前 H3 LoRA 的生态热点仍集中在加速，人物与画风训练处于早期。',
+      pipelineLabel: '下一条流水线 / 自动出片',
+      pipeline: ['组织提示词', '生成音视频', '自动剪辑与交付'],
+    },
+    faq: {
+      index: '03 / 常见问题',
+      title: '先把边界讲清楚。',
+      description: '关于模型命名、生成模式、案例来源和审核方式。',
+      items: [
+        ['MiniMax H3 和 Hailuo 3.0 是什么关系？', '本项目把 MiniMax H3 作为模型名称，同时覆盖社区常用的 Hailuo 3.0 / 海螺 3.0 检索表达，方便找到同一技术生态下的视频案例。'],
+        ['这里有哪些 AI 视频生成模式？', '当前收录 T2VA 文字生视频、FL2VA 首尾帧条件视频，以及 Ref2VA 全模态参考视频；案例可包含图像、视频、声音、对白和时间轴控制。'],
+        ['X 上发现的案例会自动发布吗？', '不会。浏览器任务只写入候选队列；核对模型、作者、原帖、提示词来源和版权风险并经人工批准后，才进入公开案例库。'],
+        ['为什么有些案例没有完整提示词？', '我们不会推断或伪造未公开提示词。案例仍可用于观察模型效果，但会明确标注提示词来源和信息缺口。'],
+      ],
+    },
+    footer: {
+      mark: '开放社区档案',
+      note: '仅收录公开来源；版权归原作者所有。发现错误或希望移除内容，请提交 Issue。',
+    },
+  },
+  en: {
+    htmlLang: 'en',
+    siteTitle: 'Awesome MiniMax H3 — Video Case Library',
+    siteDescription: 'A filterable, source-attributed MiniMax H3 / Hailuo 3.0 video case library with in-site playback.',
+    nav: { cases: 'Cases', toolkit: 'Toolkit', faq: 'FAQ', source: 'Source', language: 'ZH' },
+    intro: {
+      kicker: 'COMMUNITY VIDEO ARCHIVE / 2026',
+      lineOne: 'H3',
+      lineTwo: 'FIELD NOTES',
+      description: 'A field archive of MiniMax H3 video experiments',
+      ready: 'Case browser ready',
+      skip: 'Skip intro',
+    },
+    catalog: {
+      index: '01 / CASE INDEX',
+      title: 'See the result. Trace the workflow.',
+      description: 'Public videos, prompt provenance, and generation paths. Open any cover to watch in place.',
+      searchLabel: 'Search cases',
+      searchPlaceholder: 'Search cases, scenes, workflows…',
+      clearSearch: 'Clear search',
+      filterLabel: 'Case filters',
+      mode: 'Generation mode',
+      advanced: 'More filters',
+      advancedActive: 'More filters · Active',
+      category: 'Category',
+      style: 'Visual style',
+      scene: 'Scene',
+      resultUnit: 'cases',
+      noMatchesEyebrow: 'NO MATCHES',
+      noMatches: 'Try another search or filter.',
+    },
+    card: {
+      open: (title: string) => `View details for ${title}`,
+      cover: (title: string) => `Video cover for ${title}`,
+      play: 'Play',
+      view: 'View',
+      verified: 'Official reproduction',
+      community: 'X community',
+    },
+    dialog: {
+      close: 'Close details',
+      seconds: 'sec',
+      prompt: 'Prompt record',
+      copy: 'Copy',
+      copied: 'Copied',
+      source: 'View original source',
+    },
+    toolkit: {
+      index: '02 / H3 TOOLKIT',
+      title: 'From prompt to finished cut.',
+      description: 'A focused workbench for the official Skills, acceleration LoRA, clip continuation, and audio-video workflows that change production speed.',
+      speedLabel: 'FIELD NOTE / SPEED STACK',
+      speedTitle: 'Stabilize the sampling chain before stacking plugins.',
+      speedBody: 'Start with Turbo LoRA + SageAttention. Use four steps for previews and six to eight for finals. EasyCache is better suited to the native 20-step workflow and should not be stacked with four-step Turbo.',
+      speedFootnote: 'The H3 LoRA ecosystem currently concentrates on acceleration; character and style training remain early.',
+      pipelineLabel: 'NEXT PIPELINE / AUTOMATED OUTPUT',
+      pipeline: ['Structure prompts', 'Generate audio + video', 'Edit and deliver'],
+    },
+    faq: {
+      index: '03 / FAQ',
+      title: 'Clear boundaries first.',
+      description: 'Model naming, generation modes, sources, and review policy.',
+      items: [
+        ['How are MiniMax H3 and Hailuo 3.0 related?', 'This project uses MiniMax H3 as the model name while also indexing the Hailuo 3.0 name commonly used by the community, so cases from the same technical ecosystem remain discoverable.'],
+        ['Which AI video generation modes are included?', 'The library currently covers T2VA text-to-video with audio, FL2VA first/last-frame conditioning, and Ref2VA multimodal reference generation with image, video, audio, dialogue, and timeline controls.'],
+        ['Are cases found on X published automatically?', 'No. Browser discovery only writes to a candidate queue. A case becomes public after a human verifies the model, author, original post, prompt provenance, and rights risk.'],
+        ['Why do some cases omit the full prompt?', 'We never infer or fabricate an undisclosed prompt. The case can still document model behavior, but its provenance and information gaps remain explicit.'],
+      ],
+    },
+    footer: {
+      mark: 'OPEN COMMUNITY ARCHIVE',
+      note: 'Public sources only; rights remain with their creators. Open an Issue to correct or remove a record.',
+    },
+  },
+} as const
+
+const modeZh: Record<'ALL' | CaseMode, string> = {
+  ALL: '全部案例',
+  T2VA: '文字生视频 + 音频',
+  FL2VA: '首尾帧视频 + 音频',
+  Ref2VA: '全模态参考',
+  Unknown: '模式待确认',
+}
+
+const modeEn: Record<'ALL' | CaseMode, string> = {
+  ALL: 'All cases',
+  T2VA: 'Text-to-Video + Audio',
+  FL2VA: 'First/Last-Frame + Audio',
+  Ref2VA: 'Multimodal Reference',
+  Unknown: 'Unconfirmed mode',
+}
+
+export function modeLabel(mode: 'ALL' | CaseMode, language: Language) {
+  return language === 'zh' ? modeZh[mode] : modeEn[mode]
+}
+
+const categoryZh: Record<string, string> = {
+  'AI Film & Multimodal Reference': 'AI 电影与多模态参考',
+  'Advertising & Comparison': '广告与模型对比',
+  'Character & Dialogue': '角色与对白',
+  'Character Consistency & Benchmark': '角色一致性与性能测试',
+  'Cinematic & Survival': '电影叙事与生存',
+  'Cinematic & Upscaling Workflow': '电影镜头与超分工作流',
+  'Cinematic & VFX': '电影镜头与视觉特效',
+  'Editing & Transformation': '视频编辑与变换',
+  'Education & Storytelling': '教育与故事表达',
+  'Food & Lifestyle': '美食与生活方式',
+  'Food & Local Generation': '美食与本地生成',
+  'Image-to-Video & Local Generation': '图片生视频与本地生成',
+  'Image-to-Video Benchmark': '图片生视频性能测试',
+  'Image-to-Video Workflow': '图片生视频工作流',
+  'Interactive UI & Model Comparison': '交互界面与模型对比',
+  'Local Generation': '本地生成',
+  'Local Generation & Audio': '本地音视频生成',
+  'Local Generation Benchmark': '本地生成性能测试',
+  'Model Comparison': '模型对比',
+  'Music Video': '音乐视频',
+  'Music Video & Multi-scene Workflow': '音乐视频与多场景工作流',
+  'Narrative Film & Local Workflow': '叙事电影与本地工作流',
+  'UGC & Advertising': 'UGC 与广告',
+}
+
+const styleZh: Record<string, string> = {
+  '1950s': '1950 年代', 'Character Edit': '角色编辑', Cinematic: '电影感', Commercial: '商业广告',
+  'Fantasy UI': '奇幻界面', 'Film Trailer': '电影预告', 'Golden Hour': '黄金时刻', 'Hand-painted': '手绘',
+  Illustrative: '插画', 'Layered Composition': '分层构图', 'Lyric Video': '歌词视频', 'Music Video': '音乐视频',
+  Narrative: '叙事', 'Narrative Film': '叙事电影', Photorealistic: '照片级写实', Polished: '精致成片',
+  Realistic: '写实', 'Sci-Fi': '科幻', 'Shallow Focus': '浅景深', 'Social UGC': '社交平台 UGC',
+  'Stop-motion': '停格动画', Stylized: '风格化', Underwater: '水下', Unspecified: '未标注',
+}
+
+const sceneZh: Record<string, string> = {
+  Blizzard: '暴风雪', 'Character sheet test': '角色表测试', 'Claude Code workflow': 'Claude Code 工作流',
+  'ComfyUI benchmark': 'ComfyUI 性能测试', 'Creature transformation': '生物形态变换', 'Deep-sea encyclopedia': '深海生物百科',
+  Dialogue: '对白', Diner: '餐厅', 'Eating ramen': '吃拉面', Editing: '视频编辑', Family: '家庭', 'Female singer': '女歌手',
+  'Five-scene sequence': '五场景序列', 'Flight scene': '飞行场景', 'Fluid Simulation': '流体模拟', 'Fluid test': '流体测试',
+  Food: '美食', 'Fur test': '毛发测试', 'I2V performance test': 'I2V 性能测试', 'Krea-to-H3 workflow': 'Krea 到 H3 工作流',
+  'Localized Advertising': '本地化广告', 'Model Comparison': '模型对比', 'Mother and child': '母子',
+  'Multi-reference film trailer': '多参考图电影预告', 'Music Storytelling': '音乐叙事', 'Music Video': '音乐视频',
+  'Music video': '音乐视频', 'Object Composition': '对象分层构图', 'Person Replacement': '人物替换',
+  'Product Advertising': '产品广告', 'Product Seeding': '商品种草', 'Rainy Tokyo': '雨中东京', 'Rendered text': '文字渲染',
+  'Same-prompt comparison': '同提示词对比', Storytelling: '故事叙述', Survival: '生存', 'Textbook Recreation': '课本场景复刻',
+  'The White Camellia': '白山茶', 'Time Freeze': '时间冻结', 'Turbo LoRA test': 'Turbo LoRA 测试', 'UI interaction': '界面交互', VFX: '视觉特效',
+}
+
+export type TaxonomyKind = 'category' | 'style' | 'scene'
+
+export function taxonomyLabel(value: string, language: Language, kind: TaxonomyKind) {
+  if (value === 'ALL') return language === 'zh' ? '全部' : 'All'
+  if (language === 'en') return value
+  if (kind === 'category') return categoryZh[value] ?? value
+  if (kind === 'style') return styleZh[value] ?? value
+  return sceneZh[value] ?? value
+}
+
+export function caseTitle(item: VideoCase, language: Language) {
+  return language === 'zh' ? item.title : item.titleEn
+}
+
+export function caseSummary(item: VideoCase, language: Language) {
+  return language === 'zh' ? item.summary : item.summaryEn
+}
+
+export function casePrompt(item: VideoCase, language: Language) {
+  if (language === 'zh') return item.prompt
+  return item.promptEn ?? item.prompt
+}
+
+export function sourceLabel(item: VideoCase, language: Language) {
+  if (language === 'zh') return item.sourceLabel
+  if (item.sourceType === 'official') return 'MiniMax official reproduction script'
+  const handle = item.sourceUrl.match(/x\.com\/([^/]+)/)?.[1]
+  return item.sourceType === 'x' ? `Original X post${handle ? ` · @${handle}` : ''}` : `Community source · ${item.author}`
+}
+
+export function modelLabel(item: VideoCase, language: Language) {
+  if (language === 'zh') return item.model
+  return item.model
+    .replace('（创作者标注）', ' (creator-identified)')
+    .replace(/^MiniMax H3 与 (.+) 对比$/, 'MiniMax H3 vs $1')
+    .replaceAll(' 与 ', ' vs ')
+}
+
+export function metadataValue(value: string, language: Language) {
+  if (language === 'en' && value === '原帖') return 'Original post'
+  if (language === 'en' && value === '原帖未标注') return 'Not specified in the original post'
+  return value
+}
+
+const provenanceZh: Record<VideoCase['promptProvenance'], string> = {
+  'official-verbatim': '官方原文',
+  'official-adapted': '官方改写',
+  'creator-verbatim': '创作者原文',
+  reconstructed: '人工重建',
+  unknown: '未公开 / 待确认',
+}
+
+const provenanceEn: Record<VideoCase['promptProvenance'], string> = {
+  'official-verbatim': 'Official verbatim',
+  'official-adapted': 'Official adapted',
+  'creator-verbatim': 'Creator verbatim',
+  reconstructed: 'Reconstructed',
+  unknown: 'Undisclosed / unconfirmed',
+}
+
+export function provenanceLabel(value: VideoCase['promptProvenance'], language: Language) {
+  return language === 'zh' ? provenanceZh[value] : provenanceEn[value]
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1541,3 +1541,638 @@ footer > span {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Case-first application shell */
+body.intro-open {
+  overflow: hidden;
+}
+
+.site-header-wrap {
+  position: sticky;
+  z-index: 60;
+  top: 0;
+  border-bottom: 1px solid rgba(66, 70, 61, 0.78);
+  background: rgba(10, 11, 9, 0.9);
+  backdrop-filter: blur(18px);
+}
+
+.site-header {
+  height: 64px;
+  border: 0;
+}
+
+.site-header nav a[aria-current='page'] {
+  color: var(--ink);
+}
+
+.site-header nav a[aria-current='page']::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  background: var(--acid);
+  box-shadow: 0 0 10px rgba(217, 255, 67, 0.5);
+}
+
+.header-actions {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.language-button {
+  min-height: 36px;
+  padding: 0 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  border: 1px solid #383c34;
+  transition: color 180ms ease, border-color 180ms ease;
+}
+
+.language-button:hover {
+  color: var(--acid);
+  border-color: var(--acid);
+}
+
+.source-button {
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.intro-splash {
+  position: fixed;
+  z-index: 120;
+  inset: 0;
+  overflow: hidden;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 78% 28%, rgba(217, 255, 67, 0.08), transparent 28rem),
+    #090a08;
+  transition: clip-path 520ms cubic-bezier(0.76, 0, 0.24, 1), opacity 420ms ease;
+  clip-path: inset(0 0 0 0);
+}
+
+.intro-splash.is-leaving {
+  opacity: 0.45;
+  clip-path: inset(0 0 100% 0);
+}
+
+.intro-grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.52;
+  background-image:
+    linear-gradient(rgba(217, 255, 67, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(217, 255, 67, 0.055) 1px, transparent 1px);
+  background-size: min(8vw, 110px) min(8vw, 110px);
+  mask-image: linear-gradient(to bottom, #000 10%, transparent 92%);
+}
+
+.intro-topline,
+.intro-bottomline {
+  position: absolute;
+  z-index: 2;
+  right: clamp(24px, 4vw, 64px);
+  left: clamp(24px, 4vw, 64px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.intro-topline {
+  top: clamp(24px, 4vw, 52px);
+}
+
+.intro-topline > span,
+.intro-ready {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.intro-topline i,
+.intro-ready > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--acid);
+  box-shadow: 0 0 14px rgba(217, 255, 67, 0.72);
+}
+
+.intro-topline button {
+  padding: 8px 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.intro-topline button:hover {
+  color: var(--acid);
+}
+
+.intro-wordmark {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  left: 50%;
+  width: calc(100% - clamp(48px, 8vw, 128px));
+  transform: translate(-50%, -52%);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--display);
+  font-size: clamp(92px, 17vw, 260px);
+  font-weight: 700;
+  line-height: 0.72;
+  letter-spacing: -0.075em;
+  text-transform: uppercase;
+}
+
+.intro-wordmark span {
+  color: var(--acid);
+  animation: intro-mark-in 620ms cubic-bezier(0.2, 0.75, 0.25, 1) both;
+}
+
+.intro-wordmark strong {
+  align-self: flex-end;
+  color: transparent;
+  -webkit-text-stroke: 1.5px #8c9184;
+  animation: intro-mark-in 620ms 90ms cubic-bezier(0.2, 0.75, 0.25, 1) both;
+}
+
+@keyframes intro-mark-in {
+  from { opacity: 0; transform: translateY(48px); }
+}
+
+.intro-bottomline {
+  bottom: clamp(32px, 5vw, 70px);
+  align-items: flex-end;
+}
+
+.intro-bottomline p {
+  max-width: 430px;
+  margin: 0;
+  color: #b9bdb2;
+  font-family: 'Noto Sans SC', sans-serif;
+  font-size: clamp(14px, 1.5vw, 20px);
+  font-weight: 300;
+  line-height: 1.6;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.intro-ready {
+  color: var(--acid);
+}
+
+.intro-progress {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: #22251f;
+}
+
+.intro-progress span {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: var(--acid);
+  transform-origin: left;
+  animation: intro-progress 1.6s linear both;
+}
+
+@keyframes intro-progress {
+  from { transform: scaleX(0); }
+}
+
+.catalog {
+  padding: 38px 0 100px;
+  border-top: 0;
+}
+
+.catalog-bar {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 420px);
+  align-items: center;
+}
+
+.catalog-heading h1 {
+  max-width: 860px;
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(38px, 5vw, 70px);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+  text-transform: uppercase;
+}
+
+.catalog-heading > p:last-child {
+  max-width: 660px;
+  margin: 13px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 300;
+  line-height: 1.7;
+}
+
+.primary-filter {
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.primary-filter .filter-label {
+  padding: 0;
+  border: 0;
+}
+
+.mode-filter {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(118px, 1fr));
+}
+
+.mode-filter button {
+  min-height: 56px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  border-left: 1px solid #1e211c;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-align: left;
+  transition: color 180ms ease, background 180ms ease;
+}
+
+.mode-filter button span {
+  color: #5d6158;
+  font-size: 8px;
+}
+
+.mode-filter button:hover {
+  color: var(--ink);
+  background: #11130f;
+}
+
+.mode-filter button.active {
+  color: #0a0b09;
+  background: var(--acid);
+}
+
+.mode-filter button.active span {
+  color: rgba(10, 11, 9, 0.55);
+}
+
+.advanced-filters {
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.advanced-filters summary {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.advanced-filters summary::-webkit-details-marker {
+  display: none;
+}
+
+.advanced-filters summary > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.advanced-filters summary svg {
+  transition: transform 180ms ease;
+}
+
+.advanced-filters[open] summary svg:last-child {
+  transform: rotate(180deg);
+}
+
+.advanced-filters .filter-panel {
+  margin: 0;
+  border-top: 1px solid #1c1e1b;
+  border-bottom: 0;
+}
+
+.catalog-count {
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.catalog-count span {
+  margin-right: 6px;
+  color: var(--acid);
+  font-family: var(--display);
+  font-size: 18px;
+}
+
+.case-grid {
+  gap: 48px 22px;
+}
+
+.case-card,
+.case-card:nth-child(3n + 2),
+.case-card:nth-child(even) {
+  transform: none;
+}
+
+.media {
+  aspect-ratio: 16 / 9;
+}
+
+.case-title h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.03em;
+  transition: color 180ms ease;
+}
+
+.case-title:hover h2 {
+  color: var(--acid);
+}
+
+.case-model-line {
+  margin-top: 18px;
+  color: #72776d;
+  font-family: var(--mono);
+  font-size: 9px;
+}
+
+.standalone-page {
+  min-height: calc(100vh - 184px);
+}
+
+.page-hero {
+  min-height: 350px;
+  padding: 78px 0 52px;
+  display: grid;
+  grid-template-columns: 1fr minmax(280px, 520px);
+  align-content: end;
+  gap: 18px 8vw;
+}
+
+.page-hero .section-index {
+  grid-column: 1 / -1;
+}
+
+.page-hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(52px, 8vw, 110px);
+  line-height: 0.91;
+  letter-spacing: -0.065em;
+  text-transform: uppercase;
+}
+
+.page-hero > p:not(.section-index) {
+  align-self: end;
+  margin: 0 0 7px;
+  color: #a4a89e;
+  font-size: 15px;
+  font-weight: 300;
+  line-height: 1.85;
+}
+
+.page-hero-rule {
+  grid-column: 1 / -1;
+  height: 1px;
+  margin-top: 34px;
+  overflow: hidden;
+  background: var(--line);
+}
+
+.page-hero-rule span {
+  width: 14%;
+  height: 100%;
+  display: block;
+  background: var(--acid);
+}
+
+.toolkit-page .toolkit {
+  padding: 0 0 110px;
+  border: 0;
+}
+
+.toolkit-page .toolkit-grid {
+  margin-top: 0;
+}
+
+.resource-card h2 {
+  max-width: 520px;
+  margin: 52px 0 16px;
+  font-family: var(--display);
+  font-size: clamp(28px, 3vw, 42px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.speed-note h2 {
+  margin: 42px 0 14px;
+  font-family: var(--display);
+  font-size: 32px;
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+}
+
+.faq-page .faq {
+  padding: 0 0 110px;
+  display: block;
+  border: 0;
+}
+
+.faq-page .faq-list article {
+  padding: 34px 0;
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 24px;
+}
+
+.faq-page .faq-list article > span {
+  color: var(--acid);
+  font-family: var(--display);
+  font-size: 28px;
+}
+
+.faq-page .faq-list h2 {
+  margin: 0 0 12px;
+  font-size: 23px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.faq-page .faq-list p {
+  max-width: 760px;
+}
+
+footer {
+  min-height: 120px;
+}
+
+@media (max-width: 1100px) {
+  .mode-filter {
+    overflow-x: auto;
+    grid-template-columns: repeat(5, minmax(150px, 1fr));
+  }
+
+  .case-card {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 760px) {
+  .site-header {
+    height: auto;
+    min-height: 90px;
+    padding: 11px 0 10px;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      'brand actions'
+      'nav nav';
+    row-gap: 10px;
+  }
+
+  .site-header .brand {
+    grid-area: brand;
+  }
+
+  .site-header nav {
+    grid-area: nav;
+    display: flex;
+    gap: 24px;
+    overflow-x: auto;
+    font-size: 10px;
+  }
+
+  .header-actions {
+    grid-area: actions;
+  }
+
+  .source-button span {
+    display: none;
+  }
+
+  .intro-wordmark {
+    font-size: clamp(72px, 23vw, 145px);
+    line-height: 0.78;
+  }
+
+  .intro-wordmark strong {
+    align-self: flex-start;
+  }
+
+  .intro-bottomline {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .catalog {
+    padding-top: 28px;
+  }
+
+  .catalog-bar {
+    grid-template-columns: 1fr;
+    gap: 22px;
+  }
+
+  .primary-filter {
+    grid-template-columns: 1fr;
+  }
+
+  .primary-filter .filter-label {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .mode-filter button:first-child {
+    border-left: 0;
+  }
+
+  .case-grid {
+    display: block;
+  }
+
+  .case-card {
+    margin-bottom: 46px;
+  }
+
+  .mode-line {
+    gap: 14px;
+  }
+
+  .page-hero {
+    min-height: 330px;
+    padding-top: 58px;
+    grid-template-columns: 1fr;
+  }
+
+  .page-hero .section-index,
+  .page-hero-rule {
+    grid-column: 1;
+  }
+
+  .toolkit-page .toolkit,
+  .faq-page .faq {
+    padding-bottom: 80px;
+  }
+
+  .resource-card h2 {
+    margin-top: 38px;
+  }
+
+  .faq-page .faq-list article {
+    grid-template-columns: 46px 1fr;
+    gap: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro-wordmark span,
+  .intro-wordmark strong,
+  .intro-progress span {
+    animation: none !important;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ export interface VideoCase {
   model: string
   mode: CaseMode
   summary: string
+  summaryEn: string
   prompt: string
+  promptEn?: string
   sourceUrl: string
   sourceLabel: string
   author: string


### PR DESCRIPTION
## Summary

- replace the long landing page with a two-second opening transition over a case-first home
- add fully isolated Chinese and English routes, including localized cases and X player states
- move Toolkit and FAQ to standalone bilingual pages; remove Templates and collection-method sections from home
- generate bilingual deep links, canonical/hreflang metadata, and a 56-URL sitemap
- harden X embed loading, retry behavior, covers, and failure states

## Verification

- `npm test` — 14 passed
- `npm run lint`
- `npm run validate:data`
- `npm run build` — 6 app routes and 50 localized case pages
- desktop and 390×844 mobile browser verification
- all 28 English HTML files scanned with no CJK leakage

## Deployment

Railway tracks `main`; merging this PR should trigger the production deployment automatically.
