### PR TITLE
Add source-checked H3 tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ No account, API key, or local model setup is required to browse the public galle
 | Scan all cases without leaving GitHub | [`CATALOG.md`](./CATALOG.md) |
 | Query the source-attributed dataset | [`data/cases.json`](./data/cases.json) or [`llms-full.txt`](./public/llms-full.txt) |
 | Find a case through an Agent Skill | [`minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) |
-| Set up MiniMax H3, ComfyUI, or acceleration tools | [Tutorials and deployment resources](https://h3-field-notes-production.up.railway.app/en/toolkit/) |
+| Set up MiniMax H3 on Mac, ComfyUI, or acceleration tools | [Searchable H3 tutorials](https://h3-field-notes-production.up.railway.app/en/tutorials/) |
 
 ## H3 tutorials and deployment guides
 
 | Resource | Start here for | Link |
 | --- | --- | --- |
+| h3.c / h3-metal | Native Apple Silicon inference in pure C + Metal, without Python, PyTorch, or ComfyUI | [antirez/h3.c](https://github.com/antirez/h3.c) |
 | Official MiniMax H3 repository | Weights, deployment guidance, and nine bundled Agent Skills including `h3-prompt-writing` | [MiniMax-AI/MiniMax-H3](https://github.com/MiniMax-AI/MiniMax-H3) |
 | MiniMax-H3 Turbo LoRA | Few-step synchronized audio-video generation; use 4 steps for previews and typically 6–8 for stronger v4 output | [larryvrh/MiniMax-H3-Turbo-Lora](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) |
 | ComfyUI H3 Motion Context | Chaining clips while carrying motion and audio context across joins | [NikoDemon80/ComfyUI-H3-Motion-Context](https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context) |
-| MiniMax H3 Audio T8 | Native H3 audio conditioning, dual-clock sampling, mixing, trimming, preflight, and Ref2VA workflows | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
+| MiniMax H3 Audio T8 | A 56-node native H3 suite for stable audio conditioning and dual-clock sampling plus clearly separated experimental workflows | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
 
-A practical acceleration starting point is **Turbo LoRA + SageAttention**. EasyCache targets the native 20-step path and is not recommended on top of a 4-step Turbo graph. Fewer sampling steps also do not translate into the same end-to-end speedup because VAE decoding and video packaging remain. These external deployment resources are documented separately from the case archive; the archive does not derive prompts or production workflows from collected videos.
+The standalone tutorials page lets users search and filter these routes, see who each project is for, and follow three source-checked first steps before opening the original documentation. These external resources are documented separately from the case archive; the archive does not derive prompts or production workflows from collected videos.
 
 ## Generation modes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,18 +40,19 @@
 | 不离开 GitHub 快速浏览全部案例 | [`CATALOG.md`](./CATALOG.md) |
 | 查询带来源的结构化数据 | [`data/cases.json`](./data/cases.json) 或 [`llms-full.txt`](./public/llms-full.txt) |
 | 让 Agent 帮你查找案例 | [`minimax-h3-prompt-library`](./agents/skills/minimax-h3-prompt-library/) |
-| 部署 MiniMax H3、ComfyUI 与加速工具 | [教程与部署资源](https://h3-field-notes-production.up.railway.app/toolkit/) |
+| 在 Mac、ComfyUI 上部署 H3 或使用加速工具 | [可搜索的 H3 教程](https://h3-field-notes-production.up.railway.app/tutorials/) |
 
 ## H3 教程与部署入口
 
 | 资源 | 先看什么 | 地址 |
 | --- | --- | --- |
+| h3.c / h3-metal | Apple Silicon 原生 C + Metal 推理，不依赖 Python、PyTorch 或 ComfyUI | [antirez/h3.c](https://github.com/antirez/h3.c) |
 | MiniMax H3 官方仓库 | 权重、部署说明，以及包括 `h3-prompt-writing` 在内的 9 个 Agent Skill | [MiniMax-AI/MiniMax-H3](https://github.com/MiniMax-AI/MiniMax-H3) |
 | MiniMax-H3 Turbo LoRA | 4–8 步同步音视频加速；4 步预览，v4 在 6–8 步通常更稳 | [larryvrh/MiniMax-H3-Turbo-Lora](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) |
 | ComfyUI H3 Motion Context | 多片段续接，延续上一段的画面运动与音频上下文 | [NikoDemon80/ComfyUI-H3-Motion-Context](https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context) |
-| MiniMax H3 Audio T8 | 原生 H3 音频条件、双时钟采样、混音、裁切、预检与 Ref2VA 工作流 | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
+| MiniMax H3 Audio T8 | 56 个原生 H3 节点：稳定音频条件与双时钟采样，以及明确隔离的实验工作流 | [T8mars/comfyui-minimax-h3-audio-T8](https://github.com/T8mars/comfyui-minimax-h3-audio-T8) |
 
-实践路线优先尝试 **Turbo LoRA + SageAttention**。EasyCache 更适合原生 20 步链路，不建议和 4 步 Turbo 叠加；采样步数的缩短也不等于端到端等比例加速，VAE 解码和视频封装仍会占用时间。这些外部部署资源与案例档案分开维护；案例库不会从收录视频中派生提示词或制作流程。
+独立教程页支持按平台和能力搜索、筛选，先说明每个项目适合谁，再给出三步起跑方式和原始文档入口。这些外部资源与案例档案分开维护；案例库不会从收录视频中派生提示词或制作流程。
 
 ## 自动采集路线
 

--- a/data/tutorials.json
+++ b/data/tutorials.json
@@ -1,0 +1,197 @@
+[
+  {
+    "id": "antirez-h3-metal",
+    "code": "T01",
+    "category": "mac",
+    "featured": true,
+    "title": "h3.c / h3-metal",
+    "url": "https://github.com/antirez/h3.c",
+    "kind": {
+      "zh": "MAC 原生 / C + METAL",
+      "en": "NATIVE MAC / C + METAL"
+    },
+    "description": {
+      "zh": "antirez 从零实现的 Apple Silicon 原生 MiniMax H3 推理引擎。无需 Python、PyTorch 或 ComfyUI，已打通文生音视频、首尾帧控制与有序 Ref2VA 参考。",
+      "en": "Antirez's native MiniMax H3 inference engine for Apple Silicon, built without Python, PyTorch, or ComfyUI. Text-to-audio-video, first/last-frame control, and ordered Ref2VA references work end to end."
+    },
+    "audience": {
+      "zh": "适合希望直接在 Apple Silicon 上本地运行 H3，并愿意使用命令行的 Mac 用户。",
+      "en": "For Mac users who want to run H3 locally on Apple Silicon and are comfortable with a command line."
+    },
+    "steps": {
+      "zh": [
+        "准备 Apple Silicon Mac、官方 Hugging Face 权重，并确保 FFmpeg 与 FFprobe 已加入 PATH。",
+        "运行 make -j8，再用 ./h3 --info -d ./MiniMax-H3 检查模型目录和 Metal 设备。",
+        "不传 -p 即可进入交互会话；用 !first、!last 或 !ref-image 设置条件，再输入提示词生成。"
+      ],
+      "en": [
+        "Prepare an Apple Silicon Mac, the official Hugging Face weights, and FFmpeg plus FFprobe on PATH.",
+        "Run make -j8, then inspect the model layout and Metal device with ./h3 --info -d ./MiniMax-H3.",
+        "Start without -p for an interactive session; set !first, !last, or !ref-image before entering a prompt."
+      ]
+    },
+    "facts": ["Pure C + Metal", "No Python / PyTorch", "T2VA · FL2VA · Ref2VA"],
+    "tags": ["Apple Silicon", "Metal", "CLI", "FFmpeg"],
+    "action": {
+      "zh": "阅读 Mac 原生教程",
+      "en": "Read the native Mac tutorial"
+    },
+    "verifiedAt": "2026-08-11"
+  },
+  {
+    "id": "official-minimax-h3",
+    "code": "T02",
+    "category": "official",
+    "featured": false,
+    "title": "MiniMax-AI / MiniMax-H3",
+    "url": "https://github.com/MiniMax-AI/MiniMax-H3",
+    "kind": {
+      "zh": "官方 / 权重 + AGENT SKILL",
+      "en": "OFFICIAL / WEIGHTS + AGENT SKILL"
+    },
+    "description": {
+      "zh": "官方权重、部署说明与九个 Agent Skill 的总入口。h3-prompt-writing 可在 Claude、Codex 等 Agent 中按镜头、对白和环境声组织提示词。",
+      "en": "The official entry point for weights, deployment documentation, and nine Agent Skills. h3-prompt-writing structures shots, dialogue, and environmental audio in agents including Claude and Codex."
+    },
+    "audience": {
+      "zh": "适合第一次部署 H3，或希望先建立可靠提示词写法的用户。",
+      "en": "For first-time H3 deployment and anyone who wants a reliable prompt-writing baseline."
+    },
+    "steps": {
+      "zh": [
+        "先确认任务类型：FL2VA 权重覆盖文字与首尾帧，Ref2VA 权重用于多模态参考。",
+        "需要提示词助手时，运行 npx skills add 官方仓库地址 --skill h3-prompt-writing。",
+        "本地推理按硬件选择 SGLang、vLLM、Diffusers 或官方 ComfyUI 教程，并先复现公开样例。"
+      ],
+      "en": [
+        "Choose the task family first: FL2VA covers text and first/last-frame inputs; Ref2VA handles multimodal references.",
+        "Install the prompt helper with npx skills add and the official repository URL, followed by --skill h3-prompt-writing.",
+        "Pick SGLang, vLLM, Diffusers, or the official ComfyUI tutorial for your hardware, then reproduce a published example first."
+      ]
+    },
+    "facts": ["9 Agent Skills", "Official Weights", "4–15s · 24 FPS"],
+    "tags": ["Official", "Prompt Writing", "SGLang", "ComfyUI"],
+    "action": {
+      "zh": "打开官方部署文档",
+      "en": "Open official deployment docs"
+    },
+    "verifiedAt": "2026-08-11"
+  },
+  {
+    "id": "turbo-lora",
+    "code": "T03",
+    "category": "acceleration",
+    "featured": false,
+    "title": "MiniMax-H3 Turbo LoRA",
+    "url": "https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora",
+    "kind": {
+      "zh": "加速 / COMFYUI LORA",
+      "en": "ACCELERATION / COMFYUI LORA"
+    },
+    "description": {
+      "zh": "把常规约 20 步的同步音视频采样压缩到 4–8 步。当前 v4 EMA 更适合大多数任务；6–8 步质量更稳，4 步主要用于快速预览。",
+      "en": "Compresses the usual roughly 20-step synchronized audio-video sampling path to four to eight steps. The current v4 EMA suits most work; six to eight steps are steadier, while four is primarily for previews."
+    },
+    "audience": {
+      "zh": "适合已经跑通 ComfyUI H3，下一步想缩短采样时间的用户。",
+      "en": "For users who already have H3 working in ComfyUI and want shorter sampling times."
+    },
+    "steps": {
+      "zh": [
+        "安装配套 ComfyUI-MiniMax-H3-Turbo 节点，并准备官方 H3 基模、双 VAE 与文本编码器。",
+        "优先放入 v4 step600 EMA 权重，在官方工作流的模型加载器与采样器之间插入 Turbo LoRA。",
+        "调度器使用 simple、强度先保持 1.0；从 6–8 步成片，4 步只做快速预览。"
+      ],
+      "en": [
+        "Install the companion ComfyUI-MiniMax-H3-Turbo nodes and prepare the H3 base model, both VAEs, and the text encoder.",
+        "Prefer the v4 step600 EMA weight and insert Turbo LoRA between the official workflow's model loader and sampler.",
+        "Keep the scheduler on simple and strength at 1.0; use six to eight steps for finals and four for quick previews."
+      ]
+    },
+    "facts": ["4–8 Steps", "v4 EMA", "Synchronized Audio"],
+    "tags": ["LoRA", "ComfyUI", "Acceleration", "Audio + Video"],
+    "action": {
+      "zh": "查看权重与工作流",
+      "en": "View weights and workflow"
+    },
+    "verifiedAt": "2026-08-11"
+  },
+  {
+    "id": "motion-context",
+    "code": "T04",
+    "category": "long-video",
+    "featured": false,
+    "title": "ComfyUI H3 Motion Context",
+    "url": "https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context",
+    "kind": {
+      "zh": "长视频 / 运动 + 音频续接",
+      "en": "LONG VIDEO / MOTION + AUDIO CONTEXT"
+    },
+    "description": {
+      "zh": "把上一段的 H3 画面 latent 与音频上下文带入下一段，让运动方向、节奏与声音跨片段继续，而不是重新生成一个相似开头。",
+      "en": "Carries the previous clip's H3 visual latent and audio context into the next clip so motion, rhythm, and sound continue across the join instead of restarting with a similar take."
+    },
+    "audience": {
+      "zh": "适合制作超过单次生成时长的连续镜头、音乐段落或叙事视频。",
+      "en": "For continuous shots, music sequences, or narratives that exceed one generation window."
+    },
+    "steps": {
+      "zh": [
+        "把仓库目录放进 ComfyUI/custom_nodes 并重启；节点只在首次运行续接图时安装运行时补丁。",
+        "用 Save/Load Latent 把上一段的联合音画 latent 接入下一次运行，避免像素与音频的有损往返。",
+        "从 context_length 22、audio_context_length 22、match_tail 开始，并关闭 Spectrum。"
+      ],
+      "en": [
+        "Place the repository in ComfyUI/custom_nodes and restart; runtime patches install only when a chaining graph first runs.",
+        "Carry the previous joint audio-video latent through Save/Load Latent to avoid lossy pixel and audio round trips.",
+        "Start with context_length 22, audio_context_length 22, match_tail enabled, and Spectrum off."
+      ]
+    },
+    "facts": ["Latent Chaining", "Motion Continuity", "Audio Continuity"],
+    "tags": ["Long Video", "ComfyUI", "Context", "Audio"],
+    "action": {
+      "zh": "阅读续接教程",
+      "en": "Read the chaining tutorial"
+    },
+    "verifiedAt": "2026-08-11"
+  },
+  {
+    "id": "audio-t8",
+    "code": "T05",
+    "category": "audio",
+    "featured": false,
+    "title": "MiniMax H3 Audio T8",
+    "url": "https://github.com/T8mars/comfyui-minimax-h3-audio-T8",
+    "kind": {
+      "zh": "音频 / COMFYUI 工作流",
+      "en": "AUDIO / COMFYUI WORKFLOWS"
+    },
+    "description": {
+      "zh": "面向 ComfyUI 原生 H3 的音画节点集，覆盖稳定双时钟采样、音频条件、混音、裁切与预检，并提供长视频、语音、关键帧和来源音画重绘等实验路线。",
+      "en": "A native ComfyUI H3 audio-video node suite covering stable dual-clock sampling, audio conditioning, mixing, trimming, and preflight, plus experimental long-video, speech, keyframe, and source-AV paths."
+    },
+    "audience": {
+      "zh": "适合需要精细控制 H3 原生声音、对白、混音或音画时间线的进阶用户。",
+      "en": "For advanced users who need finer control over H3 native sound, dialogue, mixing, or audio-video timing."
+    },
+    "steps": {
+      "zh": [
+        "将项目放入 ComfyUI/custom_nodes/minimax-h3-audio-T8；稳定基础节点没有额外 pip 依赖。",
+        "先从 Audio Conditioning、Preflight、Dual-Clock Sampler、AV Decode 与 Output Trim 的稳定链路开始。",
+        "长视频、语音、多关键帧和来源音画重绘均标为实验能力，应按仓库验证记录逐项启用。"
+      ],
+      "en": [
+        "Place the project in ComfyUI/custom_nodes/minimax-h3-audio-T8; the stable base nodes add no pip dependencies.",
+        "Begin with the stable Audio Conditioning, Preflight, Dual-Clock Sampler, AV Decode, and Output Trim path.",
+        "Long-video, speech, multi-keyframe, and source-AV paths are experimental and should be enabled one at a time against the repository's validation notes."
+      ]
+    },
+    "facts": ["56 Nodes", "Dual Clock", "Stable + Experimental"],
+    "tags": ["Audio", "ComfyUI", "Mixing", "Ref2VA"],
+    "action": {
+      "zh": "打开音画节点文档",
+      "en": "Open the audio-video node docs"
+    },
+    "verifiedAt": "2026-08-11"
+  }
+]

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,71 @@
-# H3 Field Notes — Complete MiniMax H3 Case Index
+# H3 Field Notes — Complete MiniMax H3 Case and Tutorial Index
 
 Generated from data/cases.json. Total: 304 cases. Verbatim public prompts: 25.
+
+## Tutorials
+
+### h3.c / h3-metal
+
+- Route: NATIVE MAC / C + METAL
+- Best for: For Mac users who want to run H3 locally on Apple Silicon and are comfortable with a command line.
+- Summary: Antirez's native MiniMax H3 inference engine for Apple Silicon, built without Python, PyTorch, or ComfyUI. Text-to-audio-video, first/last-frame control, and ordered Ref2VA references work end to end.
+- Source checked: 2026-08-11
+- Original documentation: https://github.com/antirez/h3.c
+- Start here:
+  1. Prepare an Apple Silicon Mac, the official Hugging Face weights, and FFmpeg plus FFprobe on PATH.
+  2. Run make -j8, then inspect the model layout and Metal device with ./h3 --info -d ./MiniMax-H3.
+  3. Start without -p for an interactive session; set !first, !last, or !ref-image before entering a prompt.
+
+### MiniMax-AI / MiniMax-H3
+
+- Route: OFFICIAL / WEIGHTS + AGENT SKILL
+- Best for: For first-time H3 deployment and anyone who wants a reliable prompt-writing baseline.
+- Summary: The official entry point for weights, deployment documentation, and nine Agent Skills. h3-prompt-writing structures shots, dialogue, and environmental audio in agents including Claude and Codex.
+- Source checked: 2026-08-11
+- Original documentation: https://github.com/MiniMax-AI/MiniMax-H3
+- Start here:
+  1. Choose the task family first: FL2VA covers text and first/last-frame inputs; Ref2VA handles multimodal references.
+  2. Install the prompt helper with npx skills add and the official repository URL, followed by --skill h3-prompt-writing.
+  3. Pick SGLang, vLLM, Diffusers, or the official ComfyUI tutorial for your hardware, then reproduce a published example first.
+
+### MiniMax-H3 Turbo LoRA
+
+- Route: ACCELERATION / COMFYUI LORA
+- Best for: For users who already have H3 working in ComfyUI and want shorter sampling times.
+- Summary: Compresses the usual roughly 20-step synchronized audio-video sampling path to four to eight steps. The current v4 EMA suits most work; six to eight steps are steadier, while four is primarily for previews.
+- Source checked: 2026-08-11
+- Original documentation: https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora
+- Start here:
+  1. Install the companion ComfyUI-MiniMax-H3-Turbo nodes and prepare the H3 base model, both VAEs, and the text encoder.
+  2. Prefer the v4 step600 EMA weight and insert Turbo LoRA between the official workflow's model loader and sampler.
+  3. Keep the scheduler on simple and strength at 1.0; use six to eight steps for finals and four for quick previews.
+
+### ComfyUI H3 Motion Context
+
+- Route: LONG VIDEO / MOTION + AUDIO CONTEXT
+- Best for: For continuous shots, music sequences, or narratives that exceed one generation window.
+- Summary: Carries the previous clip's H3 visual latent and audio context into the next clip so motion, rhythm, and sound continue across the join instead of restarting with a similar take.
+- Source checked: 2026-08-11
+- Original documentation: https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context
+- Start here:
+  1. Place the repository in ComfyUI/custom_nodes and restart; runtime patches install only when a chaining graph first runs.
+  2. Carry the previous joint audio-video latent through Save/Load Latent to avoid lossy pixel and audio round trips.
+  3. Start with context_length 22, audio_context_length 22, match_tail enabled, and Spectrum off.
+
+### MiniMax H3 Audio T8
+
+- Route: AUDIO / COMFYUI WORKFLOWS
+- Best for: For advanced users who need finer control over H3 native sound, dialogue, mixing, or audio-video timing.
+- Summary: A native ComfyUI H3 audio-video node suite covering stable dual-clock sampling, audio conditioning, mixing, trimming, and preflight, plus experimental long-video, speech, keyframe, and source-AV paths.
+- Source checked: 2026-08-11
+- Original documentation: https://github.com/T8mars/comfyui-minimax-h3-audio-T8
+- Start here:
+  1. Place the project in ComfyUI/custom_nodes/minimax-h3-audio-T8; the stable base nodes add no pip dependencies.
+  2. Begin with the stable Audio Conditioning, Preflight, Dual-Clock Sampler, AV Decode, and Output Trim path.
+  3. Long-video, speech, multi-keyframe, and source-AV paths are experimental and should be enabled one at a time against the repository's validation notes.
+
+
+## Video cases
 
 ## After the Fleet Jumps
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,8 +14,8 @@
 
 - https://h3-field-notes-production.up.railway.app/ — Chinese case library
 - https://h3-field-notes-production.up.railway.app/en/ — English case library
-- https://h3-field-notes-production.up.railway.app/toolkit/ — tutorials and deployment resources
-- https://h3-field-notes-production.up.railway.app/en/toolkit/ — English tutorials and deployment resources
+- https://h3-field-notes-production.up.railway.app/tutorials/ — Mac, official deployment, acceleration, long-video, and audio tutorials
+- https://h3-field-notes-production.up.railway.app/en/tutorials/ — English H3 tutorials
 - https://h3-field-notes-production.up.railway.app/faq/ — source, prompt, playback, and review policy
 - https://h3-field-notes-production.up.railway.app/llms-full.txt — complete machine-readable case index
 - https://github.com/SkyNotSilent/awesome-minimax-h3/blob/main/data/cases.json — source dataset
@@ -42,6 +42,14 @@
 - https://h3-field-notes-production.up.railway.app/en/cases/x-2086785719604052241/ — MiniMax H3 Community Video Example by @Haruka1425054; Unknown; not-published; source: https://x.com/Haruka1425054/status/2086785719604052241
 - https://h3-field-notes-production.up.railway.app/en/cases/x-2086704420587458621/ — MiniMax H3 Local Generation by @makotwi0104; Unknown; not-published; source: https://x.com/makotwi0104/status/2086704420587458621
 - https://h3-field-notes-production.up.railway.app/en/cases/x-2086841608746553784/ — MiniMax H3 Community Video Example by @jerrod_lew; Unknown; not-published; source: https://x.com/jerrod_lew/status/2086841608746553784
+
+## Tutorial sources
+
+- h3.c / h3-metal — NATIVE MAC / C + METAL; Antirez's native MiniMax H3 inference engine for Apple Silicon, built without Python, PyTorch, or ComfyUI. Text-to-audio-video, first/last-frame control, and ordered Ref2VA references work end to end.; source checked 2026-08-11; https://github.com/antirez/h3.c
+- MiniMax-AI / MiniMax-H3 — OFFICIAL / WEIGHTS + AGENT SKILL; The official entry point for weights, deployment documentation, and nine Agent Skills. h3-prompt-writing structures shots, dialogue, and environmental audio in agents including Claude and Codex.; source checked 2026-08-11; https://github.com/MiniMax-AI/MiniMax-H3
+- MiniMax-H3 Turbo LoRA — ACCELERATION / COMFYUI LORA; Compresses the usual roughly 20-step synchronized audio-video sampling path to four to eight steps. The current v4 EMA suits most work; six to eight steps are steadier, while four is primarily for previews.; source checked 2026-08-11; https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora
+- ComfyUI H3 Motion Context — LONG VIDEO / MOTION + AUDIO CONTEXT; Carries the previous clip's H3 visual latent and audio context into the next clip so motion, rhythm, and sound continue across the join instead of restarting with a similar take.; source checked 2026-08-11; https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context
+- MiniMax H3 Audio T8 — AUDIO / COMFYUI WORKFLOWS; A native ComfyUI H3 audio-video node suite covering stable dual-clock sampling, audio conditioning, mixing, trimming, and preflight, plus experimental long-video, speech, keyframe, and source-AV paths.; source checked 2026-08-11; https://github.com/T8mars/comfyui-minimax-h3-audio-T8
 
 ## Retrieval rules
 

--- a/scripts/build-discovery-files.mjs
+++ b/scripts/build-discovery-files.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 const root = resolve(import.meta.dirname, '..')
 const baseUrl = (process.env.PUBLIC_SITE_URL || 'https://h3-field-notes-production.up.railway.app').replace(/\/$/, '')
 const cases = JSON.parse(await readFile(resolve(root, 'data/cases.json'), 'utf8'))
+const tutorials = JSON.parse(await readFile(resolve(root, 'data/tutorials.json'), 'utf8'))
 const officialCount = cases.filter((item) => item.sourceType === 'official').length
 const xCount = cases.filter((item) => item.sourceType === 'x').length
 const promptCases = cases.filter((item) => item.promptProvenance !== 'not-published')
@@ -31,8 +32,8 @@ const llms = `# H3 Field Notes — Awesome MiniMax H3
 
 - ${baseUrl}/ — Chinese case library
 - ${baseUrl}/en/ — English case library
-- ${baseUrl}/toolkit/ — tutorials and deployment resources
-- ${baseUrl}/en/toolkit/ — English tutorials and deployment resources
+- ${baseUrl}/tutorials/ — Mac, official deployment, acceleration, long-video, and audio tutorials
+- ${baseUrl}/en/tutorials/ — English H3 tutorials
 - ${baseUrl}/faq/ — source, prompt, playback, and review policy
 - ${baseUrl}/llms-full.txt — complete machine-readable case index
 - https://github.com/SkyNotSilent/awesome-minimax-h3/blob/main/data/cases.json — source dataset
@@ -40,6 +41,10 @@ const llms = `# H3 Field Notes — Awesome MiniMax H3
 ## Representative examples
 
 ${representatives.map((item) => `- ${caseUrl(item.id, 'en')} — ${item.titleEn}; ${item.mode}; ${item.promptProvenance}; source: ${item.sourceUrl}`).join('\n')}
+
+## Tutorial sources
+
+${tutorials.map((item) => `- ${item.title} — ${item.kind.en}; ${item.description.en}; source checked ${item.verifiedAt}; ${item.url}`).join('\n')}
 
 ## Retrieval rules
 
@@ -49,9 +54,24 @@ ${representatives.map((item) => `- ${caseUrl(item.id, 'en')} — ${item.titleEn}
 - Do not derive a prompt or hidden workflow from a finished video.
 `
 
-const llmsFull = `# H3 Field Notes — Complete MiniMax H3 Case Index
+const llmsFull = `# H3 Field Notes — Complete MiniMax H3 Case and Tutorial Index
 
 Generated from data/cases.json. Total: ${cases.length} cases. Verbatim public prompts: ${promptCases.length}.
+
+## Tutorials
+
+${tutorials.map((item) => `### ${item.title}
+
+- Route: ${item.kind.en}
+- Best for: ${item.audience.en}
+- Summary: ${item.description.en}
+- Source checked: ${item.verifiedAt}
+- Original documentation: ${item.url}
+- Start here:
+${item.steps.en.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}
+`).join('\n')}
+
+## Video cases
 
 ${cases.map((item) => `## ${item.titleEn}
 

--- a/scripts/build-seo-pages.mjs
+++ b/scripts/build-seo-pages.mjs
@@ -5,6 +5,7 @@ const root = resolve(import.meta.dirname, '..')
 const dist = resolve(root, 'dist')
 const baseUrl = (process.env.PUBLIC_SITE_URL || 'https://h3-field-notes-production.up.railway.app').replace(/\/$/, '')
 const cases = JSON.parse(await readFile(resolve(root, 'data/cases.json'), 'utf8'))
+const tutorials = JSON.parse(await readFile(resolve(root, 'data/tutorials.json'), 'utf8'))
 
 const locales = ['zh-CN', 'en']
 const latestPublishedDate = cases
@@ -13,29 +14,6 @@ const latestPublishedDate = cases
   .sort()
   .at(-1)
   ?.slice(0, 10)
-
-const toolkitResources = [
-  {
-    name: 'MiniMax H3 official repository and Agent Skills',
-    nameZh: 'MiniMax H3 官方仓库与 Agent Skills',
-    url: 'https://github.com/MiniMax-AI/MiniMax-H3',
-  },
-  {
-    name: 'MiniMax H3 Turbo LoRA',
-    nameZh: 'MiniMax H3 Turbo LoRA 加速',
-    url: 'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
-  },
-  {
-    name: 'ComfyUI H3 Motion Context',
-    nameZh: 'ComfyUI H3 长视频续接',
-    url: 'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
-  },
-  {
-    name: 'MiniMax H3 Audio T8 workflows',
-    nameZh: 'MiniMax H3 Audio T8 音视频工作流',
-    url: 'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
-  },
-]
 
 const faqItems = {
   'zh-CN': [
@@ -73,19 +51,19 @@ const pageDefinitions = [
     },
   },
   {
-    id: 'toolkit',
-    paths: { 'zh-CN': '/toolkit/', en: '/en/toolkit/' },
+    id: 'tutorials',
+    paths: { 'zh-CN': '/tutorials/', en: '/en/tutorials/' },
     schemaType: 'CollectionPage',
     copy: {
       'zh-CN': {
-        title: 'MiniMax H3 教程与部署资源 — H3 Field Notes',
-        description: 'MiniMax H3 官方 Skills、Turbo LoRA、ComfyUI 长视频续接与音视频工作流的精选部署资源。',
-        keywords: 'MiniMax H3 部署,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio',
+        title: 'MiniMax H3 教程：Mac、部署、加速与音频 — H3 Field Notes',
+        description: 'MiniMax H3 实操教程入口：Apple Silicon 原生 h3.c、官方部署、Prompt Skill、Turbo LoRA、ComfyUI 长视频与音频工作流。',
+        keywords: 'MiniMax H3 教程,MiniMax H3 Mac,h3.c,h3-metal,MiniMax H3 部署,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,H3 Motion Context,H3 Audio',
       },
       en: {
-        title: 'MiniMax H3 Tutorials and Deployment Resources — H3 Field Notes',
-        description: 'Curated MiniMax H3 resources for official Skills, Turbo LoRA acceleration, ComfyUI clip chaining, and audio-video workflows.',
-        keywords: 'MiniMax H3 deployment,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,SageAttention,H3 Motion Context,H3 Audio',
+        title: 'MiniMax H3 Tutorials: Mac, Deployment, Acceleration and Audio — H3 Field Notes',
+        description: 'Practical MiniMax H3 tutorials for native Apple Silicon inference with h3.c, official deployment, Prompt Skills, Turbo LoRA, long-video chaining, and audio workflows.',
+        keywords: 'MiniMax H3 tutorials,MiniMax H3 Mac,h3.c,h3-metal,MiniMax H3 deployment,ComfyUI H3,h3-prompt-writing,MiniMax H3 Turbo LoRA,H3 Motion Context,H3 Audio',
       },
     },
   },
@@ -310,14 +288,15 @@ function appStructuredData(page, locale) {
     }
   }
 
-  if (page.id === 'toolkit') {
+  if (page.id === 'tutorials') {
     pageNode.mainEntity = {
       '@type': 'ItemList',
-      numberOfItems: toolkitResources.length,
-      itemListElement: toolkitResources.map((item, index) => ({
+      numberOfItems: tutorials.length,
+      itemListElement: tutorials.map((item, index) => ({
         '@type': 'ListItem',
         position: index + 1,
-        name: locale === 'en' ? item.name : item.nameZh,
+        name: item.title,
+        description: locale === 'en' ? item.description.en : item.description.zh,
         url: item.url,
       })),
     }
@@ -359,8 +338,12 @@ function fallbackMarkup(page, locale) {
       return `<li><a href="${casePath(locale, item.id)}">${escapeHtml(localized.title)}</a><small>${escapeHtml(item.mode)} · ${escapeHtml(localized.author)}</small></li>`
     }).join('')
     content = `<p><strong>${cases.length}</strong> ${escapeHtml(locale === 'en' ? 'published video examples' : '个已发布视频案例')}</p><ol>${links}</ol>`
-  } else if (page.id === 'toolkit') {
-    content = `<ul>${toolkitResources.map((item) => `<li><a href="${escapeHtml(item.url)}">${escapeHtml(locale === 'en' ? item.name : item.nameZh)}</a></li>`).join('')}</ul>`
+  } else if (page.id === 'tutorials') {
+    content = `<ol>${tutorials.map((item) => {
+      const description = locale === 'en' ? item.description.en : item.description.zh
+      const steps = locale === 'en' ? item.steps.en : item.steps.zh
+      return `<li><a href="${escapeHtml(item.url)}">${escapeHtml(item.title)}</a><p>${escapeHtml(description)}</p><ol>${steps.map((step) => `<li>${escapeHtml(step)}</li>`).join('')}</ol></li>`
+    }).join('')}</ol>`
   } else {
     content = faqItems[locale].map(([question, answer]) => `<article><h2>${escapeHtml(question)}</h2><p>${escapeHtml(answer)}</p></article>`).join('')
   }
@@ -560,6 +543,21 @@ for (const page of pageDefinitions) {
     await mkdir(pageDir, { recursive: true })
     await writeFile(resolve(pageDir, 'index.html'), html)
   }
+}
+
+const legacyTutorialRoutes = [
+  { locale: 'zh-CN', from: '/toolkit/', to: '/tutorials/', label: '教程页面已迁移，正在跳转。' },
+  { locale: 'en', from: '/en/toolkit/', to: '/en/tutorials/', label: 'The tutorials page has moved. Redirecting.' },
+]
+
+for (const route of legacyTutorialRoutes) {
+  const target = absolute(route.to)
+  const relativePath = route.from.replace(/^\//, '')
+  const pageDir = resolve(dist, relativePath)
+  const html = `<!doctype html><html lang="${route.locale}"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0;url=${escapeHtml(target)}"><meta name="robots" content="noindex,follow"><link rel="canonical" href="${escapeHtml(target)}"><title>${escapeHtml(route.label)}</title><script>location.replace(${jsonForHtml(target)})</script></head><body><p>${escapeHtml(route.label)} <a href="${escapeHtml(target)}">${escapeHtml(target)}</a></p></body></html>`
+  assertLanguageIsolation(html, route.locale, route.from)
+  await mkdir(pageDir, { recursive: true })
+  await writeFile(resolve(pageDir, 'index.html'), html)
 }
 
 for (const item of cases) {

--- a/scripts/validate-data.mjs
+++ b/scripts/validate-data.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const cases = JSON.parse(await readFile(resolve(root, 'data/cases.json'), 'utf8'))
+const tutorials = JSON.parse(await readFile(resolve(root, 'data/tutorials.json'), 'utf8'))
 const modes = new Set(['T2VA', 'FL2VA', 'Ref2VA', 'Unknown'])
 const provenance = new Set(['official-verbatim', 'creator-verbatim', 'not-published'])
 const ids = new Set()
@@ -61,8 +62,40 @@ for (const [index, item] of cases.entries()) {
   }
 }
 
+const tutorialIds = new Set()
+const tutorialCodes = new Set()
+const tutorialCategories = new Set(['mac', 'official', 'acceleration', 'long-video', 'audio'])
+
+for (const [index, item] of tutorials.entries()) {
+  const at = `tutorials[${index}]`
+  for (const key of ['id', 'code', 'category', 'title', 'url', 'verifiedAt']) {
+    if (!item[key]) errors.push(`${at}.${key} is required`)
+  }
+  if (tutorialIds.has(item.id)) errors.push(`${at}.id is duplicated: ${item.id}`)
+  if (tutorialCodes.has(item.code)) errors.push(`${at}.code is duplicated: ${item.code}`)
+  tutorialIds.add(item.id)
+  tutorialCodes.add(item.code)
+  if (!tutorialCategories.has(item.category)) errors.push(`${at}.category is invalid: ${item.category}`)
+  if (Number.isNaN(Date.parse(item.verifiedAt))) errors.push(`${at}.verifiedAt must be a valid date`)
+  try {
+    new URL(item.url)
+  } catch {
+    errors.push(`${at}.url is invalid`)
+  }
+  for (const key of ['kind', 'description', 'audience', 'action']) {
+    if (!item[key]?.zh || !item[key]?.en) errors.push(`${at}.${key} requires zh and en values`)
+    if (/[\u3400-\u9fff]/u.test(item[key]?.en || '')) errors.push(`${at}.${key}.en must not contain CJK text`)
+  }
+  if (!Array.isArray(item.steps?.zh) || item.steps.zh.length < 2) errors.push(`${at}.steps.zh must contain at least two steps`)
+  if (!Array.isArray(item.steps?.en) || item.steps.en.length < 2) errors.push(`${at}.steps.en must contain at least two steps`)
+  if (item.steps?.en?.some((step) => /[\u3400-\u9fff]/u.test(step))) errors.push(`${at}.steps.en must not contain CJK text`)
+  for (const key of ['facts', 'tags']) {
+    if (!Array.isArray(item[key]) || item[key].length === 0) errors.push(`${at}.${key} must be a non-empty array`)
+  }
+}
+
 if (errors.length) {
   console.error(errors.join('\n'))
   process.exit(1)
 }
-console.log(`Validated ${cases.length} cases.`)
+console.log(`Validated ${cases.length} cases and ${tutorials.length} tutorials.`)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -51,11 +51,11 @@ describe('case-first routes', () => {
   it('keeps the home page focused on cases and removes template and collection-method sections', () => {
     renderAt('/')
     expect(screen.getByRole('link', { name: '案例' })).toHaveAttribute('href', '/')
-    expect(screen.getByRole('link', { name: '工具链' })).toHaveAttribute('href', '/toolkit/')
+    expect(screen.getByRole('link', { name: '教程' })).toHaveAttribute('href', '/tutorials/')
     expect(screen.getByRole('link', { name: '常见问题' })).toHaveAttribute('href', '/faq/')
     expect(screen.queryByText('从单个案例，提炼可复用镜头协议。')).not.toBeInTheDocument()
     expect(screen.queryByText('收录方式')).not.toBeInTheDocument()
-    expect(screen.queryByText('H3 工具，按需取用。')).not.toBeInTheDocument()
+    expect(screen.queryByText('从案例，走到真正跑起来。')).not.toBeInTheDocument()
   })
 
   it('renders translated style and scene chips without duplicate React keys', () => {
@@ -119,21 +119,33 @@ describe('case-first routes', () => {
     await waitFor(() => expect(createTweet).toHaveBeenCalled())
   })
 
-  it('publishes Toolkit and FAQ as standalone pages', () => {
-    const toolkit = renderAt('/toolkit/')
-    expect(screen.getByRole('heading', { name: 'H3 工具，按需取用。' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'MiniMax-AI / MiniMax-H3: 打开官方仓库' })).toHaveAttribute(
+  it('publishes Tutorials and FAQ as standalone pages', () => {
+    const tutorials = renderAt('/tutorials/')
+    expect(screen.getByRole('heading', { name: '从案例，走到真正跑起来。' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'MiniMax-AI / MiniMax-H3: 打开官方部署文档' })).toHaveAttribute(
       'href',
       'https://github.com/MiniMax-AI/MiniMax-H3',
     )
+    expect(screen.getByRole('link', { name: '阅读 Mac 原生教程' })).toHaveAttribute(
+      'href',
+      'https://github.com/antirez/h3.c',
+    )
     expect(screen.queryByRole('heading', { name: '先看 MiniMax H3 的真实效果。' })).not.toBeInTheDocument()
-    toolkit.unmount()
+    tutorials.unmount()
 
     renderAt('/faq/')
     expect(screen.getByRole('heading', { name: '先把边界讲清楚。' })).toBeInTheDocument()
     expect(screen.getByText('这里收录什么？')).toBeInTheDocument()
     expect(screen.getByText('这里展示的 Prompt 会被修改吗？')).toBeInTheDocument()
     expect(screen.queryByText('打开官方仓库')).not.toBeInTheDocument()
+  })
+
+  it('filters tutorial routes without mixing them into the case catalog', () => {
+    renderAt('/tutorials/')
+    fireEvent.click(screen.getByRole('button', { name: '长视频' }))
+    expect(screen.getByRole('heading', { name: 'ComfyUI H3 Motion Context' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'h3.c / h3-metal' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'MiniMax-H3 Turbo LoRA' })).not.toBeInTheDocument()
   })
 })
 
@@ -145,16 +157,23 @@ describe('language isolation', () => {
     expect(screen.getByText('After the Fleet Jumps')).toBeInTheDocument()
     expect(screen.queryByText('舰桥上的跃迁余震')).not.toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search cases, scenes, or creators…')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Toolkit' })).toHaveAttribute('href', '/en/toolkit/')
+    expect(screen.getByRole('link', { name: 'Tutorials' })).toHaveAttribute('href', '/en/tutorials/')
     expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/')
     expect(document.body.textContent).not.toMatch(/[\u3400-\u9fff]/u)
   })
 
   it('keeps the language switch on the equivalent standalone route', () => {
-    renderAt('/en/toolkit/')
-    expect(screen.getByRole('heading', { name: 'H3 tools, ready when you need them.' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/toolkit/')
+    renderAt('/en/tutorials/')
+    expect(screen.getByRole('heading', { name: 'From watching examples to running H3.' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/tutorials/')
     expect(screen.queryByText('打开官方仓库')).not.toBeInTheDocument()
+    expect(document.body.textContent).not.toMatch(/[\u3400-\u9fff]/u)
+  })
+
+  it('keeps the old toolkit URL as a client-side compatibility alias', () => {
+    renderAt('/en/toolkit/')
+    expect(screen.getByRole('heading', { name: 'From watching examples to running H3.' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Switch to Chinese' })).toHaveAttribute('href', '/tutorials/')
   })
 
   it('localizes the English X player and case dialog', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   X,
 } from 'lucide-react'
 import rawCases from '../data/cases.json'
+import rawTutorials from '../data/tutorials.json'
 import {
   casePath,
   casePrompt,
@@ -35,77 +36,47 @@ import type { CaseMode, VideoCase } from './types'
 import { XPostEmbed } from './XPostEmbed'
 
 const cases = rawCases as VideoCase[]
+type TutorialCategory = 'mac' | 'official' | 'acceleration' | 'long-video' | 'audio'
+type LocalizedText = Record<Language, string>
+type TutorialResource = {
+  id: string
+  code: string
+  category: TutorialCategory
+  featured: boolean
+  title: string
+  url: string
+  kind: LocalizedText
+  description: LocalizedText
+  audience: LocalizedText
+  steps: Record<Language, string[]>
+  facts: string[]
+  tags: string[]
+  action: LocalizedText
+  verifiedAt: string
+}
+
+const tutorials = rawTutorials as TutorialResource[]
+const tutorialCategories: Array<'all' | TutorialCategory> = ['all', 'mac', 'official', 'acceleration', 'long-video', 'audio']
 const modes: Array<'ALL' | CaseMode> = ['ALL', 'T2VA', 'FL2VA', 'Ref2VA', 'Unknown']
 const allCategories = [...new Set(cases.map((item) => item.category))]
 const allStyles = [...new Set(cases.flatMap((item) => item.styles))]
 const allScenes = [...new Set(cases.flatMap((item) => item.scenes))]
 
-const toolkitResources = [
-  {
-    code: 'R01',
-    kind: { zh: '官方 / AGENT SKILLS', en: 'OFFICIAL / AGENT SKILLS' },
-    title: 'MiniMax-AI / MiniMax-H3',
-    description: {
-      zh: '官方仓库与本地部署入口。内置 9 个 Agent Skill；先装 h3-prompt-writing，让 Claude / Codex 按镜头、对白与环境声组织 H3 提示词。',
-      en: 'The official repository and local deployment entry point. Its nine Agent Skills include h3-prompt-writing for structuring shots, dialogue, and environmental audio with Claude or Codex.',
-    },
-    tags: ['9 Skills', 'Prompt Writing', 'Local Deploy'],
-    url: 'https://github.com/MiniMax-AI/MiniMax-H3',
-    action: { zh: '打开官方仓库', en: 'Open official repository' },
-  },
-  {
-    code: 'R02',
-    kind: { zh: '加速 / LORA', en: 'ACCELERATION / LORA' },
-    title: 'MiniMax-H3 Turbo LoRA',
-    description: {
-      zh: '将常规约 20 步采样压缩到 4–8 步并保留同步立体声音频。4 步用于快速预览，v4 版本在 6–8 步通常更稳。',
-      en: 'Compresses the usual 20-step sampling path to four to eight steps while retaining synchronized stereo audio. Four steps suit previews; v4 is generally steadier at six to eight.',
-    },
-    tags: ['4–8 Steps', 'Audio + Video', 'ComfyUI'],
-    url: 'https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora',
-    action: { zh: '打开 Hugging Face', en: 'Open on Hugging Face' },
-  },
-  {
-    code: 'R03',
-    kind: { zh: '长视频 / 上下文', en: 'LONG VIDEO / CONTEXT' },
-    title: 'ComfyUI H3 Motion Context',
-    description: {
-      zh: '用于多段 H3 视频续接，把上一段的画面与音频上下文带入下一段，减少连接处的动作、节奏和声音断裂。',
-      en: 'Carries visual and audio context from one H3 clip into the next, reducing breaks in motion, rhythm, and sound across longer sequences.',
-    },
-    tags: ['Clip Chaining', 'Motion Context', 'Audio Continuity'],
-    url: 'https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context',
-    action: { zh: '打开续接节点', en: 'Open continuation nodes' },
-  },
-  {
-    code: 'R04',
-    kind: { zh: '音频 / 工作流', en: 'AUDIO / WORKFLOWS' },
-    title: 'MiniMax H3 Audio T8',
-    description: {
-      zh: '面向 ComfyUI 原生 H3 的 14 节点扩展，覆盖音频条件、双时钟采样、混音、裁切、预检和 Ref2VA 参考，并附 API 与前端工作流。',
-      en: 'A 14-node extension for native H3 in ComfyUI, covering audio conditioning, dual-clock sampling, mixing, trimming, preflight checks, Ref2VA references, API use, and frontend workflows.',
-    },
-    tags: ['14 Nodes', 'Dual Clock', 'Audio Control'],
-    url: 'https://github.com/T8mars/comfyui-minimax-h3-audio-T8',
-    action: { zh: '打开音频工作流', en: 'Open audio workflows' },
-  },
-]
-
 function App() {
   const route = resolveRoute(window.location.pathname)
   const language = route.language
   const t = copy[language]
-  const pageDescription = route.page === 'toolkit'
-    ? t.toolkit.description
+  const pageDescription = route.page === 'tutorials'
+    ? t.tutorials.description
     : route.page === 'faq'
       ? t.faq.description
       : t.siteDescription
   const pageTitle = route.page === 'home'
     ? t.siteTitle
-    : route.page === 'toolkit'
+    : route.page === 'tutorials'
       ? language === 'zh'
-        ? 'MiniMax H3 工具链与部署资源 — H3 Field Notes'
-        : 'MiniMax H3 Toolkit and Deployment Resources — H3 Field Notes'
+        ? 'MiniMax H3 教程：Mac、部署、加速与音频 — H3 Field Notes'
+        : 'MiniMax H3 Tutorials: Mac, Deployment, Acceleration and Audio — H3 Field Notes'
       : language === 'zh'
         ? 'MiniMax H3 视频案例库常见问题 — H3 Field Notes'
         : 'MiniMax H3 Video Library FAQ — H3 Field Notes'
@@ -121,7 +92,7 @@ function App() {
       <div className="grain" aria-hidden="true" />
       <Header language={language} page={route.page} />
       {route.page === 'home' && <HomePage language={language} />}
-      {route.page === 'toolkit' && <ToolkitPage language={language} />}
+      {route.page === 'tutorials' && <TutorialsPage language={language} />}
       {route.page === 'faq' && <FaqPage language={language} />}
       <Footer language={language} />
     </main>
@@ -140,7 +111,7 @@ function Header({ language, page }: { language: Language; page: AppPage }) {
         </a>
         <nav aria-label={language === 'zh' ? '主导航' : 'Primary navigation'}>
           <a href={pathFor(language, 'home')} aria-current={page === 'home' ? 'page' : undefined}>{t.nav.cases}</a>
-          <a href={pathFor(language, 'toolkit')} aria-current={page === 'toolkit' ? 'page' : undefined}>{t.nav.toolkit}</a>
+          <a href={pathFor(language, 'tutorials')} aria-current={page === 'tutorials' ? 'page' : undefined}>{t.nav.tutorials}</a>
           <a href={pathFor(language, 'faq')} aria-current={page === 'faq' ? 'page' : undefined}>{t.nav.faq}</a>
         </nav>
         <div className="header-actions">
@@ -425,43 +396,118 @@ function PageHero({ index, title, description }: { index: string; title: string;
   )
 }
 
-function ToolkitPage({ language }: { language: Language }) {
-  const t = copy[language].toolkit
+function TutorialsPage({ language }: { language: Language }) {
+  const t = copy[language].tutorials
+  const [activeCategory, setActiveCategory] = useState<(typeof tutorialCategories)[number]>('all')
+  const [query, setQuery] = useState('')
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return tutorials.filter((item) => {
+      const categoryMatches = activeCategory === 'all' || item.category === activeCategory
+      const searchable = [
+        item.title,
+        item.kind[language],
+        item.description[language],
+        item.audience[language],
+        ...item.steps[language],
+        ...item.facts,
+        ...item.tags,
+      ].join(' ').toLowerCase()
+      return categoryMatches && (!needle || searchable.includes(needle))
+    })
+  }, [activeCategory, language, query])
+
+  const featured = filtered.find((item) => item.featured)
+  const remaining = filtered.filter((item) => !item.featured)
 
   return (
-    <div className="standalone-page toolkit-page">
+    <div className="standalone-page tutorials-page">
       <PageHero index={t.index} title={t.title} description={t.description} />
-      <section className="toolkit shell" aria-label={copy[language].nav.toolkit}>
-        <div className="toolkit-grid">
-          {toolkitResources.map((item) => (
-            <a className="resource-card" href={item.url} target="_blank" rel="noreferrer" key={item.code} aria-label={`${item.title}: ${item.action[language]}`}>
-              <div className="resource-topline"><span>{item.code}</span><span>{item.kind[language]}</span></div>
-              <h2>{item.title}</h2>
-              <p>{item.description[language]}</p>
-              <div className="resource-tags">{item.tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
-              <div className="resource-action">{item.action[language]} <ArrowUpRight size={15} /></div>
-            </a>
-          ))}
+      <section className="tutorial-hub shell" aria-label={copy[language].nav.tutorials}>
+        <div className="tutorial-controls">
+          <label className="tutorial-search">
+            <Search size={16} aria-hidden="true" />
+            <span className="sr-only">{t.searchLabel}</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder={t.searchPlaceholder} />
+            {query && <button type="button" onClick={() => setQuery('')} aria-label={t.clearSearch}><X size={14} /></button>}
+          </label>
+          <div className="tutorial-filters" role="group" aria-label={t.filterLabel}>
+            {tutorialCategories.map((category) => (
+              <button
+                type="button"
+                key={category}
+                className={activeCategory === category ? 'active' : ''}
+                aria-pressed={activeCategory === category}
+                onClick={() => setActiveCategory(category)}
+              >
+                {t.categories[category]}
+              </button>
+            ))}
+          </div>
         </div>
 
-        <div className="toolkit-notes">
-          <article className="speed-note">
-            <div className="note-label">{t.speedLabel}</div>
-            <h2>{t.speedTitle}</h2>
-            <p>{t.speedBody}</p>
-            <small>{t.speedFootnote}</small>
-          </article>
-          <article className="pipeline-note principles-note">
-            <div className="note-label">{t.principlesLabel}</div>
-            <div className="pipeline-flow principles-flow" aria-label={t.principlesLabel}>
-              <div><span>01</span><strong>VIDEO</strong><small>{t.principles[0]}</small></div>
-              <ChevronRight size={18} aria-hidden="true" />
-              <div><span>02</span><strong>SOURCE</strong><small>{t.principles[1]}</small></div>
-              <ChevronRight size={18} aria-hidden="true" />
-              <div><span>03</span><strong>PROMPT</strong><small>{t.principles[2]}</small></div>
+        {featured && (
+          <article className="tutorial-feature">
+            <div className="tutorial-feature-copy">
+              <div className="resource-topline"><span>{featured.code} / {t.featuredLabel}</span><span>{featured.kind[language]}</span></div>
+              <h2>{featured.title}</h2>
+              <p className="tutorial-summary">{featured.description[language]}</p>
+              <p className="tutorial-audience"><strong>{t.bestFor}</strong>{featured.audience[language]}</p>
+              <div className="resource-tags">{featured.facts.map((fact) => <span key={fact}>{fact}</span>)}</div>
+              <a className="tutorial-link" href={featured.url} target="_blank" rel="noreferrer">
+                {featured.action[language]} <ArrowUpRight size={16} />
+              </a>
+            </div>
+            <div className="tutorial-feature-steps">
+              <div className="tutorial-step-heading"><span>{t.startLabel}</span><small>{t.verified} {featured.verifiedAt}</small></div>
+              <ol>
+                {featured.steps[language].map((step, index) => (
+                  <li key={step}><span>{String(index + 1).padStart(2, '0')}</span><p>{step}</p></li>
+                ))}
+              </ol>
+              <div className="tutorial-command" aria-label={t.commandLabel}>
+                <code>make -j8</code>
+                <code>./h3 --info -d ./MiniMax-H3</code>
+              </div>
             </div>
           </article>
-        </div>
+        )}
+
+        {remaining.length > 0 && (
+          <div className="tutorial-grid">
+            {remaining.map((item) => (
+              <article className="tutorial-card" key={item.id}>
+                <div className="resource-topline"><span>{item.code}</span><span>{item.kind[language]}</span></div>
+                <h2>{item.title}</h2>
+                <p className="tutorial-summary">{item.description[language]}</p>
+                <p className="tutorial-audience"><strong>{t.bestFor}</strong>{item.audience[language]}</p>
+                <ol className="tutorial-card-steps">
+                  {item.steps[language].map((step, index) => (
+                    <li key={step}><span>{index + 1}</span><p>{step}</p></li>
+                  ))}
+                </ol>
+                <div className="resource-tags">{item.facts.map((fact) => <span key={fact}>{fact}</span>)}</div>
+                <div className="tutorial-card-footer">
+                  <small>{t.verified} {item.verifiedAt}</small>
+                  <a href={item.url} target="_blank" rel="noreferrer" aria-label={`${item.title}: ${item.action[language]}`}>
+                    {item.action[language]} <ArrowUpRight size={15} />
+                  </a>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {!featured && remaining.length === 0 && (
+          <div className="tutorial-empty"><span>00</span><p>{t.noResults}</p></div>
+        )}
+
+        <aside className="tutorial-field-note">
+          <div><span>{t.fieldNoteLabel}</span><h2>{t.fieldNoteTitle}</h2></div>
+          <p>{t.fieldNoteBody}</p>
+          <small>{t.sourceNote}</small>
+        </aside>
       </section>
     </div>
   )

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,7 +1,7 @@
 import type { CaseMode, VideoCase } from './types'
 
 export type Language = 'zh' | 'en'
-export type AppPage = 'home' | 'toolkit' | 'faq'
+export type AppPage = 'home' | 'tutorials' | 'faq'
 
 export interface AppRoute {
   language: Language
@@ -12,7 +12,11 @@ export function resolveRoute(pathname: string): AppRoute {
   const segments = pathname.split('/').filter(Boolean)
   const language: Language = segments[0] === 'en' ? 'en' : 'zh'
   const pageSegment = segments[language === 'en' ? 1 : 0]
-  const page: AppPage = pageSegment === 'toolkit' || pageSegment === 'faq' ? pageSegment : 'home'
+  const page: AppPage = pageSegment === 'tutorials' || pageSegment === 'toolkit'
+    ? 'tutorials'
+    : pageSegment === 'faq'
+      ? 'faq'
+      : 'home'
   return { language, page }
 }
 
@@ -30,7 +34,7 @@ export const copy = {
     htmlLang: 'zh-CN',
     siteTitle: 'Awesome MiniMax H3 — 视频案例库',
     siteDescription: '可筛选、可追溯、可站内观看的 MiniMax H3 / Hailuo 3.0 视频案例库。',
-    nav: { cases: '案例', toolkit: '工具链', faq: '常见问题', source: '源码', language: 'EN' },
+    nav: { cases: '案例', tutorials: '教程', faq: '常见问题', source: '源码', language: 'EN' },
     intro: {
       kicker: 'COMMUNITY VIDEO ARCHIVE / 2026',
       lineOne: 'H3',
@@ -76,16 +80,32 @@ export const copy = {
       copied: '已复制',
       source: '查看原始来源',
     },
-    toolkit: {
-      index: '02 / H3 工具链',
-      title: 'H3 工具，按需取用。',
-      description: '官方仓库、加速 LoRA、长视频续接与音视频节点独立整理，方便需要时直接查阅。',
-      speedLabel: '实战笔记 / 速度组合',
-      speedTitle: '少叠插件，先把采样链路跑稳。',
-      speedBody: '优先尝试 Turbo LoRA + SageAttention。4 步适合预览，6–8 步用于成片；EasyCache 更适合原生 20 步工作流，不建议和 4 步 Turbo 叠加。',
-      speedFootnote: '当前 H3 LoRA 的生态热点仍集中在加速，人物与画风训练处于早期。',
-      principlesLabel: '案例库原则 / VIDEO FIRST',
-      principles: ['真实视频优先', '原始来源可查', 'Prompt 只收原文'],
+    tutorials: {
+      index: '02 / H3 教程',
+      title: '从案例，走到真正跑起来。',
+      description: '为 Mac 原生、官方部署、ComfyUI 加速、长视频续接与原生音频整理的实操入口。每条路线都给出适用对象、起步步骤与原始文档。',
+      searchLabel: '搜索教程',
+      searchPlaceholder: '搜索平台、能力或项目…',
+      clearSearch: '清除教程搜索',
+      filterLabel: '教程分类',
+      categories: {
+        all: '全部路线',
+        mac: 'Mac 原生',
+        official: '官方入门',
+        acceleration: '采样加速',
+        'long-video': '长视频',
+        audio: '音频工作流',
+      },
+      featuredLabel: '本周重点',
+      bestFor: '适合：',
+      startLabel: '三步起跑',
+      verified: '资料核验',
+      commandLabel: 'h3.c 起步命令',
+      noResults: '没有匹配的教程，换一个关键词或分类试试。',
+      fieldNoteLabel: '实战提示 / SPEED STACK',
+      fieldNoteTitle: '加速不是把开关全部打开。',
+      fieldNoteBody: 'ComfyUI 路线可先从 Turbo LoRA 的 v4 EMA、simple 调度器与 6–8 步开始。4 步更适合预览；Motion Context 明确建议关闭 Spectrum。不同加速器是否能叠加，应以各自当前 README 和固定素材 A/B 为准。',
+      sourceNote: '教程摘要只整理项目公开文档，不从案例视频反推隐藏流程。外部项目持续更新，执行前请再次查看原始 README。',
     },
     faq: {
       index: '03 / 常见问题',
@@ -107,7 +127,7 @@ export const copy = {
     htmlLang: 'en',
     siteTitle: 'Awesome MiniMax H3 — Video Case Library',
     siteDescription: 'A filterable, source-attributed MiniMax H3 / Hailuo 3.0 video case library with in-site playback.',
-    nav: { cases: 'Cases', toolkit: 'Toolkit', faq: 'FAQ', source: 'Source', language: 'ZH' },
+    nav: { cases: 'Cases', tutorials: 'Tutorials', faq: 'FAQ', source: 'Source', language: 'ZH' },
     intro: {
       kicker: 'COMMUNITY VIDEO ARCHIVE / 2026',
       lineOne: 'H3',
@@ -153,16 +173,32 @@ export const copy = {
       copied: 'Copied',
       source: 'View original source',
     },
-    toolkit: {
-      index: '02 / H3 TOOLKIT',
-      title: 'H3 tools, ready when you need them.',
-      description: 'Official resources, acceleration LoRA, clip continuation, and audio-video nodes collected in one focused reference page.',
-      speedLabel: 'FIELD NOTE / SPEED STACK',
-      speedTitle: 'Stabilize the sampling chain before stacking plugins.',
-      speedBody: 'Start with Turbo LoRA + SageAttention. Use four steps for previews and six to eight for finals. EasyCache is better suited to the native 20-step workflow and should not be stacked with four-step Turbo.',
-      speedFootnote: 'The H3 LoRA ecosystem currently concentrates on acceleration; character and style training remain early.',
-      principlesLabel: 'LIBRARY RULES / VIDEO FIRST',
-      principles: ['Real video first', 'Original source linked', 'Published prompts only'],
+    tutorials: {
+      index: '02 / H3 TUTORIALS',
+      title: 'From watching examples to running H3.',
+      description: 'Practical starting points for native Mac inference, official deployment, ComfyUI acceleration, long-video chaining, and native audio. Every route includes who it is for, first steps, and the original documentation.',
+      searchLabel: 'Search tutorials',
+      searchPlaceholder: 'Search platforms, capabilities, or projects…',
+      clearSearch: 'Clear tutorial search',
+      filterLabel: 'Tutorial categories',
+      categories: {
+        all: 'All routes',
+        mac: 'Native Mac',
+        official: 'Official setup',
+        acceleration: 'Acceleration',
+        'long-video': 'Long video',
+        audio: 'Audio workflows',
+      },
+      featuredLabel: 'FEATURED NOW',
+      bestFor: 'Best for: ',
+      startLabel: 'START IN THREE STEPS',
+      verified: 'Source checked',
+      commandLabel: 'h3.c starter commands',
+      noResults: 'No tutorial matches this search. Try another term or category.',
+      fieldNoteLabel: 'FIELD NOTE / SPEED STACK',
+      fieldNoteTitle: 'Acceleration is not every switch at once.',
+      fieldNoteBody: 'For the ComfyUI route, start with Turbo LoRA v4 EMA, the simple scheduler, and six to eight steps. Four steps suit previews; Motion Context explicitly recommends keeping Spectrum off. Test other combinations against current READMEs and fixed-input A/B renders.',
+      sourceNote: 'Tutorial summaries are grounded in public project documentation, never inferred from case videos. External projects evolve, so recheck the original README before running a guide.',
     },
     faq: {
       index: '03 / FAQ',

--- a/src/styles.css
+++ b/src/styles.css
@@ -2009,32 +2009,384 @@ body.intro-open {
   background: var(--acid);
 }
 
-.toolkit-page .toolkit {
+.tutorial-hub {
   padding: 0 0 110px;
+}
+
+.tutorial-controls {
+  margin-bottom: 28px;
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) 1.28fr;
+  gap: 12px;
+}
+
+.tutorial-search {
+  min-height: 52px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  border: 1px solid #44483f;
+  background: rgba(13, 15, 12, 0.82);
+}
+
+.tutorial-search:focus-within {
+  border-color: var(--acid);
+}
+
+.tutorial-search svg {
+  flex: 0 0 auto;
+  color: var(--acid);
+}
+
+.tutorial-search input {
+  min-width: 0;
+  flex: 1;
+  color: var(--ink);
+  background: transparent;
   border: 0;
+  outline: 0;
+  font-size: 13px;
 }
 
-.toolkit-page .toolkit-grid {
-  margin-top: 0;
+.tutorial-search input::placeholder {
+  color: #73776e;
 }
 
-.resource-card h2 {
-  max-width: 520px;
-  margin: 52px 0 16px;
+.tutorial-search button {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-content: center;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.tutorial-filters {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  border-top: 1px solid #44483f;
+  border-left: 1px solid #44483f;
+}
+
+.tutorial-filters button {
+  min-height: 52px;
+  padding: 8px 10px;
+  color: #898d83;
+  background: rgba(13, 15, 12, 0.82);
+  border: 0;
+  border-right: 1px solid #44483f;
+  border-bottom: 1px solid #44483f;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 9px;
+  line-height: 1.4;
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.tutorial-filters button:hover {
+  color: var(--ink);
+}
+
+.tutorial-filters button.active {
+  color: #090a08;
+  background: var(--acid);
+}
+
+.tutorial-feature {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  border: 1px solid var(--acid);
+  background:
+    linear-gradient(135deg, rgba(217, 255, 67, 0.055), transparent 46%),
+    #10120e;
+}
+
+.tutorial-feature-copy,
+.tutorial-feature-steps {
+  min-width: 0;
+  padding: clamp(28px, 4vw, 56px);
+}
+
+.tutorial-feature-copy {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--acid);
+}
+
+.tutorial-feature h2 {
+  max-width: 680px;
+  margin: clamp(54px, 8vw, 110px) 0 22px;
   font-family: var(--display);
-  font-size: clamp(28px, 3vw, 42px);
+  font-size: clamp(54px, 7.4vw, 112px);
   font-weight: 600;
-  line-height: 1.05;
-  letter-spacing: -0.04em;
+  line-height: 0.84;
+  letter-spacing: -0.065em;
+  text-transform: uppercase;
 }
 
-.speed-note h2 {
-  margin: 42px 0 14px;
-  font-family: var(--display);
-  font-size: 32px;
-  line-height: 1.08;
-  letter-spacing: -0.04em;
+.tutorial-summary {
+  margin: 0;
+  color: #a6aaa0;
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 1.82;
+}
+
+.tutorial-feature .tutorial-summary {
+  max-width: 720px;
+  font-size: 16px;
+}
+
+.tutorial-audience {
+  margin: 22px 0 0;
+  color: #c9ccc2;
+  font-size: 12px;
+  line-height: 1.72;
+}
+
+.tutorial-audience strong {
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.tutorial-link {
+  width: fit-content;
+  margin-top: auto;
+  padding-top: 42px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.tutorial-feature-steps {
+  color: #090a08;
+  background: var(--acid);
+}
+
+.tutorial-step-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.tutorial-step-heading small {
+  font: inherit;
+  opacity: 0.64;
+}
+
+.tutorial-feature-steps ol {
+  margin: 58px 0 42px;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid rgba(9, 10, 8, 0.32);
+}
+
+.tutorial-feature-steps li {
+  padding: 21px 0;
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 14px;
+  border-bottom: 1px solid rgba(9, 10, 8, 0.32);
+}
+
+.tutorial-feature-steps li > span {
+  font-family: var(--display);
+  font-size: 22px;
+}
+
+.tutorial-feature-steps li p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.tutorial-command {
+  padding: 15px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--acid);
+  background: #090a08;
+  overflow-x: auto;
+}
+
+.tutorial-command code {
+  font-family: var(--mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.tutorial-grid {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid #44483f;
+  border-left: 1px solid #44483f;
+}
+
+.tutorial-card {
+  min-height: 570px;
+  padding: clamp(26px, 3vw, 38px);
+  display: flex;
+  flex-direction: column;
+  background: rgba(16, 18, 14, 0.56);
+  border-right: 1px solid #44483f;
+  border-bottom: 1px solid #44483f;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.tutorial-card:hover {
+  z-index: 1;
+  background: #151812;
+  transform: translateY(-3px);
+}
+
+.tutorial-card h2 {
+  margin: 46px 0 18px;
+  font-family: var(--display);
+  font-size: clamp(34px, 4vw, 58px);
+  font-weight: 600;
+  line-height: 0.94;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+}
+
+.tutorial-card-steps {
+  margin: 30px 0 4px;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+
+.tutorial-card-steps li {
+  padding: 14px 0;
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.tutorial-card-steps li span {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-content: center;
+  color: #090a08;
+  background: var(--acid);
+  font-family: var(--mono);
+  font-size: 8px;
+}
+
+.tutorial-card-steps li p {
+  margin: 0;
+  color: #969a90;
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.tutorial-card .resource-tags {
+  margin-top: 24px;
+}
+
+.tutorial-card-footer {
+  margin-top: auto;
+  padding-top: 34px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.tutorial-card-footer small {
+  color: #696d64;
+  font-family: var(--mono);
+  font-size: 8px;
+  text-transform: uppercase;
+}
+
+.tutorial-card-footer a {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 9px;
+  text-align: right;
+}
+
+.tutorial-empty {
+  min-height: 260px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 18px;
+  color: var(--muted);
+  border: 1px solid #44483f;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.tutorial-empty span {
+  color: var(--acid);
+  font-family: var(--display);
+  font-size: 54px;
+}
+
+.tutorial-field-note {
+  margin-top: 24px;
+  padding: clamp(28px, 4vw, 48px);
+  display: grid;
+  grid-template-columns: 0.82fr 1.18fr;
+  gap: 38px 8vw;
+  color: #090a08;
+  background: var(--acid);
+}
+
+.tutorial-field-note span,
+.tutorial-field-note small {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tutorial-field-note h2 {
+  max-width: 560px;
+  margin: 38px 0 0;
+  font-family: var(--display);
+  font-size: clamp(34px, 5vw, 66px);
+  line-height: 0.94;
+  letter-spacing: -0.055em;
+  text-transform: uppercase;
+}
+
+.tutorial-field-note p {
+  align-self: end;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.78;
+}
+
+.tutorial-field-note small {
+  grid-column: 1 / -1;
+  padding-top: 18px;
+  border-top: 1px solid rgba(9, 10, 8, 0.3);
+  line-height: 1.65;
+  opacity: 0.72;
 }
 
 .faq-page .faq {
@@ -2079,6 +2431,20 @@ footer {
 
   .case-card {
     grid-column: span 6;
+  }
+
+  .tutorial-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .tutorial-feature {
+    grid-template-columns: 1fr;
+  }
+
+  .tutorial-feature-copy {
+    min-height: 540px;
+    border-right: 0;
+    border-bottom: 1px solid var(--acid);
   }
 }
 
@@ -2174,13 +2540,66 @@ footer {
     grid-column: 1;
   }
 
-  .toolkit-page .toolkit,
+  .tutorial-hub,
   .faq-page .faq {
     padding-bottom: 80px;
   }
 
-  .resource-card h2 {
+  .tutorial-filters {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .tutorial-feature-copy {
+    min-height: auto;
+  }
+
+  .tutorial-feature h2 {
+    margin-top: 68px;
+  }
+
+  .tutorial-feature .tutorial-summary {
+    font-size: 14px;
+  }
+
+  .tutorial-link {
     margin-top: 38px;
+    padding-top: 0;
+  }
+
+  .tutorial-step-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .tutorial-feature-steps ol {
+    margin-top: 36px;
+  }
+
+  .tutorial-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tutorial-card {
+    min-height: 0;
+  }
+
+  .tutorial-card-footer {
+    margin-top: 32px;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .tutorial-card-footer a {
+    text-align: left;
+  }
+
+  .tutorial-field-note {
+    grid-template-columns: 1fr;
+  }
+
+  .tutorial-field-note small {
+    grid-column: 1;
   }
 
   .faq-page .faq-list article {


### PR DESCRIPTION
## What changed

- replace the old four-link toolkit with a standalone, searchable Tutorials experience
- feature antirez/h3.c for native Apple Silicon inference and add source-checked three-step starts for five routes
- retain official MiniMax H3, Turbo LoRA, Motion Context, and Audio T8 guidance using current upstream READMEs
- keep Chinese and English routes fully isolated and preserve `/toolkit/` as a compatibility redirect
- add tutorial JSON validation, CollectionPage/ItemList structured data, sitemap routes, README links, and llms/GEO discovery content

## User impact

Users can move from watching H3 examples to choosing a practical setup route for Mac, official deployment, ComfyUI acceleration, long video, or native audio without mixing tutorial content into the case browser.

## Verification

- `npm test` — 20/20 passed
- `npm run lint`
- `npm run validate:data` — 304 cases and 5 tutorials
- `npm run build`
- browser screenshots at 1440×1000 and 390×844
- route, localization, legacy redirect, sitemap, llms index, and `git diff --check` validation