### PR TITLE
docs: align bilingual Motion Context tutorial details

### DIFF
--- a/data/tutorial-guides.json
+++ b/data/tutorial-guides.json
@@ -3505,8 +3505,8 @@
     "contentType": "community",
     "category": "long-video",
     "title": {
-      "zh": "4070 12GB：5 秒分块续接 13 秒角色舞蹈",
-      "en": "4070 12GB: chain three five-second chunks into a character dance"
+      "zh": "4070 12GB：三段约 5 秒续接成 13 秒角色舞蹈",
+      "en": "4070 12GB: chain three roughly 5-second chunks into a 13-second character dance"
     },
     "outcome": {
       "zh": "在单次 13 秒无法生成时，用 Turbo 8 步与 Motion Context 分块完成。",
@@ -3541,7 +3541,7 @@
         "用 Motion Context 续接并检查动作、声音与身份边界。"
       ],
       "en": [
-        "Split the longer motion into roughly five-second sections.",
+        "Split the longer motion into three roughly five-second sections.",
         "Use Ref2VA for character and motion reference with eight-step Turbo.",
         "Chain with Motion Context and inspect motion, audio, and identity at every join."
       ]

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -4131,7 +4131,7 @@ The creator leaderboard is derived only from source-attributed content already p
 
 
 
-### 4070 12GB: chain three five-second chunks into a character dance
+### 4070 12GB: chain three roughly 5-second chunks into a 13-second character dance
 
 - English page: https://h3-field-notes-production.up.railway.app/en/tutorials/ref2v-motion-context-chunks/
 - Chinese page: https://h3-field-notes-production.up.railway.app/tutorials/ref2v-motion-context-chunks/
@@ -4151,7 +4151,7 @@ The creator leaderboard is derived only from source-attributed content already p
 
 - Original source: https://x.com/cla_kuro37459/status/2087892024410480796
 - Start here:
-  1. Split the longer motion into roughly five-second sections.
+  1. Split the longer motion into three roughly five-second sections.
   2. Use Ref2VA for character and motion reference with eight-step Turbo.
   3. Chain with Motion Context and inspect motion, audio, and identity at every join.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -73,7 +73,7 @@
 - https://h3-field-notes-production.up.railway.app/en/tutorials/four-bit-eight-gb/ — 4-bit plus DiffSynth: an 8GB-VRAM route; acceleration; source checked 2026-08-23; original: https://x.com/ModelScope2022/status/2084625441940279770
 - https://h3-field-notes-production.up.railway.app/en/tutorials/train-ref2va-lora/ — H3 Ref2VA LoRA: a guide to community training routes; training; source checked 2026-08-23; original: https://x.com/ostrisai/status/2090540475199680543
 - https://h3-field-notes-production.up.railway.app/en/tutorials/webui-motion-context/ — H3 WebUI: Motion Context plus built-in upscaling; long-video; source checked 2026-08-23; original: https://x.com/core_tan/status/2087415961293144516
-- https://h3-field-notes-production.up.railway.app/en/tutorials/ref2v-motion-context-chunks/ — 4070 12GB: chain three five-second chunks into a character dance; long-video; source checked 2026-08-23; original: https://x.com/cla_kuro37459/status/2087892024410480796
+- https://h3-field-notes-production.up.railway.app/en/tutorials/ref2v-motion-context-chunks/ — 4070 12GB: chain three roughly 5-second chunks into a 13-second character dance; long-video; source checked 2026-08-23; original: https://x.com/cla_kuro37459/status/2087892024410480796
 - https://h3-field-notes-production.up.railway.app/en/tutorials/lightx2v-vs-larryvrh/ — Four-step vs eight-step LoRA: a 30-second chaining A/B; acceleration; source checked 2026-08-23; original: https://x.com/core_tan/status/2088147718732734936
 - https://h3-field-notes-production.up.railway.app/en/tutorials/minimax-director-timeline/ — MiniMax Director: multi-shot video with sound on a timeline; comfyui; source checked 2026-09-08; original: https://github.com/imbutus/ComfyUI-MiniMaxDirector
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -684,7 +684,7 @@ describe('case-first routes', () => {
     renderAt('/tutorials/')
     fireEvent.click(screen.getByRole('button', { name: '长视频' }))
     expect(screen.getByRole('heading', { name: 'H3 WebUI：Motion Context + 内置升频' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: '4070 12GB：5 秒分块续接 13 秒角色舞蹈' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '4070 12GB：三段约 5 秒续接成 13 秒角色舞蹈' })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Mac Studio 上用 Phosphene 跑 Turbo' })).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Align the Motion Context tutorial's Chinese and English titles so both specify three roughly five-second chunks and a 13-second character dance. Add the omitted three-chunk count to the English first step, matching the existing Chinese instruction. Refresh the generated discovery text and the existing title assertion.

## Validation

- `npm run sync:stats`
- `npm run build:reference`
- `npm run screenshots:capture`
- `npm run verify`
- `git diff --check`
